### PR TITLE
only build master on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ services:
 
 script: ./build-images.py
 
+branches:
+    only:
+        - master
+
 notifications:
     irc:
         channels:


### PR DESCRIPTION
We are currently developing with branches rather than fork + branch so
we're doing a lot of pointless Travis builds. Let's just build master
for now.