### PR TITLE
add a PATH_MAX to prevent failures due to path length on windows

### DIFF
--- a/ansible/systemd/jenkins.service
+++ b/ansible/systemd/jenkins.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run \
     --rm --read-only --tmpfs=/tmp \
     -p 50000:50000 \
     -e JENKINS_OPTS="--sessionTimeout=10080" \
+    -e JAVA_OPTS="-Djenkins.branch.WorkspaceLocatorImpl.PATH_MAX=20" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v jenkins_home:/var/jenkins_home \
     --name jenkins pyca/crypto-jenkins


### PR DESCRIPTION
On Windows the path limit is 260 characters. The jenkins branch API
adds a suffix that by default can be up to 80 characters, which puts us
over the limit on some of our longer file names. This change should
prevent that problem...for now