### PR TITLE
add an openssl master container for easier testing

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,6 +50,11 @@
         "build_args": []
     },
     {
+        "tag": "pyca/cryptography-runner-stretch-openssl-master:latest",
+        "path": "runners/stretch-openssl-master",
+        "build_args": []
+    },
+    {
         "tag": "pyca/cryptography-runner-sid:latest",
         "path": "runners/sid",
         "build_args": []

--- a/runners/stretch-openssl-master/Dockerfile
+++ b/runners/stretch-openssl-master/Dockerfile
@@ -29,11 +29,11 @@ RUN pip install -q tox
 
 WORKDIR /root
 
-RUN git clone --depth=1 https://github.com/openssl/openssl openssl
+RUN git clone --depth=1 https://github.com/openssl/openssl
 
 RUN cd openssl && \
     ./config --prefix=/opt/pyca/cryptography/openssl \
-             --openssldir=/opt/pyca/cryptography/openssl && \
+             --openssldir=/opt/pyca/cryptography/openssl no-comp && \
     make depend && \
     make -j4 && \
     make install && \

--- a/runners/stretch-openssl-master/Dockerfile
+++ b/runners/stretch-openssl-master/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:stretch
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+# This is needed because otherwise `sys.getfilesystemencoding()` returns
+# "ANSI_X3.4-1968".
+ENV LANG C.UTF-8
+
+# Docker pipeline plugin mounts the workspace into the image
+# This adds the same uid/gid that we use in the jenkins container
+# so getpwuid() won't fail when tox invokes
+RUN groupadd -g ${gid} ${group}
+RUN useradd -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+
+RUN apt-get -qq update && apt-get install -qq -y \
+    build-essential \
+    libffi-dev \
+    python-dev \
+    python3-dev \
+    git \
+    curl
+
+RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python
+
+RUN pip install -q tox
+
+WORKDIR /root
+
+RUN git clone --depth=1 https://github.com/openssl/openssl openssl
+
+RUN cd openssl && \
+    ./config --prefix=/opt/pyca/cryptography/openssl \
+             --openssldir=/opt/pyca/cryptography/openssl && \
+    make depend && \
+    make -j4 && \
+    make install && \
+    cd .. && \
+    rm -rf openssl
+
+USER jenkins


### PR DESCRIPTION
I don't want to add this into CI (yet), but it'd be nice to have a container that contains a daily OpenSSL master build that we can test with as we desire.

If we decide we want to merge this we should not merge until after I create the dockerhub repo