### PR TITLE
add an alpine runner

### DIFF
--- a/config.json
+++ b/config.json
@@ -63,5 +63,10 @@
         "tag": "pyca/cryptography-runner-ubuntu-rolling:latest",
         "path": "runners/ubuntu-rolling",
         "build_args": []
+    },
+    {
+        "tag": "pyca/cryptography-runner-alpine:latest",
+        "path": "runners/alpine",
+        "build_args": []
     }
 ]

--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:latest
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+# This is needed because otherwise `sys.getfilesystemencoding()` returns
+# "ANSI_X3.4-1968".
+ENV LANG C.UTF-8
+
+# Docker pipeline plugin mounts the workspace into the image
+# This adds the same uid/gid that we use in the jenkins container
+# so getpwuid() won't fail when tox invokes
+RUN addgroup -g ${gid} ${group}
+RUN adduser -u ${uid} -G ${group} -D ${user}
+
+RUN apk update && \
+    apk add git libffi-dev curl python-dev \
+    python3-dev libressl-dev bash gcc musl-dev
+
+RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python
+
+RUN pip install -q tox
+
+USER jenkins

--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -15,8 +15,7 @@ ENV LANG C.UTF-8
 RUN addgroup -g ${gid} ${group}
 RUN adduser -u ${uid} -G ${group} -D ${user}
 
-RUN apk update && \
-    apk add git libffi-dev curl python-dev \
+RUN apk add --no-cache git libffi-dev curl python-dev \
     python3-dev libressl-dev bash gcc musl-dev
 
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python


### PR DESCRIPTION
With the upcoming manylinux1 support we're going to see a swift shift to
the most common compilation issues coming from alpine (which is not
manylinux1 compatible). Compounding that it defaults to libressl.
We should test against it (and maybe drop the libre 2.5.3 jessie
builder)