### PR TITLE
docker changed ADD in 17.06 so that it auto-decompresses

### DIFF
--- a/runners/jessie-libressl/Dockerfile
+++ b/runners/jessie-libressl/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get -qq update && apt-get install -qq -y \
 
 ARG LIBRE_VERSION
 
-ADD https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRE_VERSION}.tar.gz .
+RUN curl -O https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRE_VERSION}.tar.gz
 RUN tar zxf libressl-${LIBRE_VERSION}.tar.gz
 
 WORKDIR libressl-${LIBRE_VERSION}


### PR DESCRIPTION
that's possibly a bug that will be fixed, but in the mean time we're broken and this will work either way.