### PR TITLE
switch to building static libs for cryptography wheels

### DIFF
--- a/cryptography-manylinux1/install_openssl.sh
+++ b/cryptography-manylinux1/install_openssl.sh
@@ -20,10 +20,10 @@ PATH=/opt/perl/bin:$PATH
 cd ${OPENSSL_NAME}
 if [[ $1 == "x86_64" ]]; then
     echo "Configuring for x86_64"
-    ./Configure linux-x86_64 no-comp enable-ec_nistp_64_gcc_128 shared --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
+    ./Configure linux-x86_64 no-comp enable-ec_nistp_64_gcc_128 no-shared no-dynamic-engine --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
 else
     echo "Configuring for i686"
-    ./Configure linux-generic32 no-comp shared --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
+    ./Configure linux-generic32 no-comp no-shared no-dynamic-engine --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
 fi
 make depend
 make -j4


### PR DESCRIPTION
no-shared implies no-dynamic-engine but I want to explicitly call it out in case we switch back to shared libs for some reason in the future

refs https://github.com/pyca/cryptography/issues/3810 and https://github.com/pyca/cryptography/issues/3804