### PR TITLE
remove python 2.6 manylinux builder for cffi

### DIFF
--- a/external-projects/Jenkinsfile-cffi-wheel-builder
+++ b/external-projects/Jenkinsfile-cffi-wheel-builder
@@ -15,8 +15,8 @@ def configs = [
         label: 'docker',
         imageName: 'quay.io/pypa/manylinux1_x86_64',
         versions: [
-            'cp26-cp26m', 'cp26-cp26mu', 'cp27-cp27m',
-            'cp27-cp27mu', 'cp33-cp33m', 'cp34-cp34m',
+            'cp27-cp27m', 'cp27-cp27mu',
+            'cp33-cp33m', 'cp34-cp34m',
             'cp35-cp35m', 'cp36-cp36m'
         ],
     ],


### PR DESCRIPTION
manylinux1 no longer ships python 2.6 binaries.