### PR TITLE
Revert cffi py_limited_api work

### DIFF
--- a/external-projects/Jenkinsfile-cffi-wheel-builder
+++ b/external-projects/Jenkinsfile-cffi-wheel-builder
@@ -1,15 +1,15 @@
 def configs = [
     [
         label: 'windows',
-        versions: ['py27', 'py34', 'py35', 'py36', 'py37'],
+        versions: ['py27', 'py33', 'py34', 'py35', 'py36', 'py37'],
     ],
     [
         label: 'windows64',
-        versions: ['py27', 'py34', 'py35', 'py36', 'py37'],
+        versions: ['py27', 'py33', 'py34', 'py35', 'py36', 'py37'],
     ],
     [
         label: 'sierra',
-        versions: ['py27', 'py34'],
+        versions: ['py27', 'py34', 'py35', 'py36', 'py37'],
     ],
     [
         label: 'docker',
@@ -17,6 +17,9 @@ def configs = [
         versions: [
             'cp27-cp27m', 'cp27-cp27mu',
             'cp34-cp34m',
+            'cp35-cp35m',
+            'cp36-cp36m',
+            'cp37-cp37m',
         ],
     ],
     [
@@ -25,6 +28,9 @@ def configs = [
         versions: [
             'cp27-cp27m', 'cp27-cp27mu',
             'cp34-cp34m',
+            'cp35-cp35m',
+            'cp36-cp36m',
+            'cp37-cp37m',
         ],
     ],
 ]
@@ -36,6 +42,7 @@ def build(version, label, imageName) {
             if (label.contains("windows")) {
                 def pythonPath = [
                     py27: "C:\\Python27\\python.exe",
+                    py33: "C:\\Python33\\python.exe",
                     py34: "C:\\Python34\\python.exe",
                     py35: "C:\\Python35\\python.exe",
                     py36: "C:\\Python36\\python.exe",
@@ -57,6 +64,9 @@ def build(version, label, imageName) {
                 def pythonPath = [
                     py27: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7",
                     py34: "/Library/Frameworks/Python.framework/Versions/3.4/bin/python3.4",
+                    py35: "/Library/Frameworks/Python.framework/Versions/3.5/bin/python3.5",
+                    py36: "/Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6",
+                    py37: "/Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7",
                 ]
                 ansiColor {
                     sh """#!/usr/bin/env bash
@@ -74,16 +84,7 @@ def build(version, label, imageName) {
                         virtualenv .venv -p ${pythonPath[version]}
                         source .venv/bin/activate
                         pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
-                        pip install pycparser
-                        pip download cffi --no-binary cffi --no-deps
-                        tar zxf cffi*
-                        pushd cffi*
-                        REGEX="py3([0-9])*"
-                        if [[ "${version}" =~ \$REGEX ]]; then
-                            PY_LIMITED_API="--py-limited-api=cp3\${BASH_REMATCH[1]}"
-                        fi
-                        python setup.py bdist_wheel --dist-dir=../wheelhouse \$PY_LIMITED_API
-                        popd
+                        pip wheel cffi --wheel-dir=wheelhouse --no-binary cffi
                         pip install -f wheelhouse cffi --no-index
                         python -c "import cffi;print(cffi.__version__)"
                     """
@@ -130,17 +131,7 @@ def build(version, label, imageName) {
                     chmod -R 777 libffi*
 
                     $linux32 /opt/python/$version/bin/pip install pycparser
-                    $linux32 /opt/python/$version/bin/pip download cffi --no-binary cffi --no-deps
-                    tar zxf cffi*
-                    pushd cffi*
-                    REGEX="cp3([0-9])*"
-                    if [[ "${version}" =~ \$REGEX ]]; then
-                        PY_LIMITED_API="--py-limited-api=cp3\${BASH_REMATCH[1]}"
-                    fi
-                    $linux32 /opt/python/$version/bin/python setup.py bdist_wheel --dist-dir=../tmpwheelhouse \$PY_LIMITED_API
-                    popd
-                    # More root use permission nonsense
-                    chmod -R 777 cffi*
+                    $linux32 /opt/python/$version/bin/pip wheel --no-binary cffi --no-deps cffi -w tmpwheelhouse/
                     $linux32 auditwheel repair tmpwheelhouse/cffi*.whl -w wheelhouse/
                     $linux32 /opt/python/$version/bin/pip install cffi --no-index -f wheelhouse/
                     $linux32 /opt/python/$version/bin/python -c "import cffi;print(cffi.__version__)"


### PR DESCRIPTION
cffi can't use the limited API. A fact I knew but forgot so do I really get to say I knew it?