### PR TITLE
add libffi to cryptography manylinux1 builders

### DIFF
--- a/cryptography-manylinux1/Dockerfile
+++ b/cryptography-manylinux1/Dockerfile
@@ -11,5 +11,7 @@ RUN tar zxf perl-5.24.1.tar.gz && \
     cd perl-5.24.1 && \
     ./Configure -des -Dprefix=/opt/perl && \
     make -j4 && make install
+ADD install_libffi.sh /root/install_libffi.sh
+RUN sh install_libffi.sh ${ARCH2ELECTRICBOOGALOO}
 ADD install_openssl.sh /root/install_openssl.sh
 RUN sh install_openssl.sh ${ARCH2ELECTRICBOOGALOO}

--- a/cryptography-manylinux1/install_libffi.sh
+++ b/cryptography-manylinux1/install_libffi.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xe
+
+LIBFFI_SHA256="d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"
+LIBFFI_VERSION="3.2.1"
+
+function check_sha256sum {
+    local fname=$1
+    local sha256=$2
+    echo "${sha256}  ${fname}" > "${fname}.sha256"
+    sha256sum -c "${fname}.sha256"
+    rm "${fname}.sha256"
+}
+
+curl -#O "https://mirrors.ocf.berkeley.edu/debian/pool/main/libf/libffi/libffi_${LIBFFI_VERSION}.orig.tar.gz"
+check_sha256sum "libffi_${LIBFFI_VERSION}.orig.tar.gz" ${LIBFFI_SHA256}
+tar zxf libffi*.orig.tar.gz
+PATH=/opt/perl/bin:$PATH
+cd libffi*
+if [[ $1 == "x86_64" ]]; then
+    echo "Configuring for x86_64"
+    ./configure CFLAGS="-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security"
+else
+    echo "Configuring for i686"
+    linux32 ./configure CFLAGS="-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security"
+fi
+make install


### PR DESCRIPTION
we need this to work around the build isolation that prevents pip wheel from using the cffi wheels