### PR TITLE
use 1809 instead of ltsc2019

### DIFF
--- a/windows/openssl/Dockerfile
+++ b/windows/openssl/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 as openssl-builder
+FROM mcr.microsoft.com/windows/servercore:1809 as openssl-builder
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/py27/Dockerfile
+++ b/windows/py27/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:1809
 
 COPY --from=pyca/openssl-windows-artifact:win32-2010 "C:/openssl-win32-2010" C:/OpenSSL-Win32-2010
 COPY --from=pyca/openssl-windows-artifact:win64-2010 "C:/openssl-win64-2010" C:/OpenSSL-Win64-2010

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:1809
 
 COPY --from=pyca/openssl-windows-artifact:win32-2015 "C:/openssl-win32-2015" C:/OpenSSL-Win32-2015
 COPY --from=pyca/openssl-windows-artifact:win64-2015 "C:/openssl-win64-2015" C:/OpenSSL-Win64-2015

--- a/windows/py34/Dockerfile
+++ b/windows/py34/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:1809
 
 COPY --from=pyca/openssl-windows-artifact:win32-2010 "C:/openssl-win32-2010" C:/OpenSSL-Win32-2010
 COPY --from=pyca/openssl-windows-artifact:win64-2010 "C:/openssl-win64-2010" C:/OpenSSL-Win64-2010

--- a/windows/py35/Dockerfile
+++ b/windows/py35/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:1809
 
 COPY --from=pyca/openssl-windows-artifact:win32-2015 "C:/openssl-win32-2015" C:/OpenSSL-Win32-2015
 COPY --from=pyca/openssl-windows-artifact:win64-2015 "C:/openssl-win64-2015" C:/OpenSSL-Win64-2015


### PR DESCRIPTION
azure pipelines is going to be caching 1809 apparently, see
https://github.com/microsoft/azure-pipelines-image-generation/blob/74573d89ae49e6be3e507c5af91758dbb2c114c9/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1