### PR TITLE
try to shrink our windows docker py3 image

### DIFF
--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -5,17 +5,9 @@ COPY --from=pyca/openssl-windows-artifact:win64-2015 "C:/openssl-win64-2015" C:/
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-
-RUN choco install -y 7zip
-RUN choco install git -y --params="/NoAutoCrlf"
-RUN choco install --ignore-package-exit-codes -y dotnetfx
-RUN choco install --ignore-package-exit-codes -y visualstudio2017buildtools
-RUN choco install --ignore-package-exit-codes -y visualstudio2017-workload-vctools --package-parameters "'--add Microsoft.VisualStudio.Component.Windows10SDK.17763 --no-includeRecommended'"
-
 COPY *.ps1 C:/scripts/
-
 ARG CPU_ARCH
 
-RUN C:/scripts/install_python.ps1 3.6.8 Python36 $env:CPU_ARCH
-RUN C:/scripts/install_python.ps1 3.7.3 Python37 $env:CPU_ARCH
+# Windows docker images are substantially larger with multiple layers, which is
+# insane, but here we are so let's do it all in one step.
+RUN C:/scripts/install_everything.ps1

--- a/windows/py3/install_everything.ps1
+++ b/windows/py3/install_everything.ps1
@@ -1,0 +1,24 @@
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+choco install --no-progress -y 7zip
+# We need to check exit code after every exe invocation because powershell has no
+# facility for doing this since Windows exit codes are inconsistent
+if ($LastExitCode -ne 0) { exit 1; }
+
+choco install --no-progress -y git --params="/NoAutoCrlf"
+if ($LastExitCode -ne 0) { exit 1; }
+
+choco install --ignore-package-exit-codes --no-progress -y dotnetfx
+if ($LastExitCode -ne 0) { exit 1; }
+
+choco install --ignore-package-exit-codes --no-progress -y visualstudio2017buildtools
+if ($LastExitCode -ne 0) { exit 1; }
+
+choco install --ignore-package-exit-codes --no-progress -y visualstudio2017-workload-vctools --package-parameters "'--add Microsoft.VisualStudio.Component.Windows10SDK.17763 --no-includeRecommended'"
+if ($LastExitCode -ne 0) { exit 1; }
+
+& C:/scripts/install_python.ps1 3.6.8 Python36 $env:CPU_ARCH
+if ($LastExitCode -ne 0) { exit 1; }
+
+& C:/scripts/install_python.ps1 3.7.3 Python37 $env:CPU_ARCH
+if ($LastExitCode -ne 0) { exit 1; };


### PR DESCRIPTION
For some bizarre reason docker layers bloat windows docker images **horribly**. In testing this PR made my (server 2016-based) image 1.8GB smaller (uncompressed).

Docker formerly checked our exit codes and powershell won't fail a script just because an exe had a non-zero exit code (since windows exit codes are not standardized) so we have to do a bunch of extra error code checking to make sure we properly fail.