### PR TITLE
Fix Windows OpenSSL building

### DIFF
--- a/windows/openssl/Dockerfile
+++ b/windows/openssl/Dockerfile
@@ -5,12 +5,10 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 RUN choco install -y 7zip nasm activeperl winrar
-RUN choco install --ignore-package-exit-codes -y dotnetfx
-RUN choco install --ignore-package-exit-codes -y visualstudio2017buildtools
-RUN choco install --ignore-package-exit-codes -y visualstudio2017-workload-vctools
-
 COPY *.ps1 /scripts/
 COPY *.bat /scripts/
+
+RUN & 'C:/scripts/vs.bat'
 
 RUN powershell -Command /scripts/install_tools.ps1 -InstallURI http://download.microsoft.com/download/F/1/0/F10113F5-B750-4969-A255-274341AC6BCE/GRMSDK_EN_DVD.iso
 

--- a/windows/openssl/vs.bat
+++ b/windows/openssl/vs.bat
@@ -1,0 +1,8 @@
+curl -fSLo vs_BuildTools.exe https://aka.ms/vs/16/release/vs_buildtools.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
+setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+start /w vs_BuildTools.exe --quiet --norestart --nocache --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended
+if %errorlevel% neq 0 exit /b %errorlevel%
+del vs_BuildTools.exe
+powershell Remove-Item -Force -Recurse "%TEMP%\*"
+rmdir /S /Q "%ProgramData%\Package Cache"


### PR DESCRIPTION
Verified by running a build already. Hooray we can compile again. Yes this is ridiculous, but hey apparently we **don't** need .NET.