### PR TITLE
Switch back to VS2017 for windows openssl

### DIFF
--- a/windows/openssl/build_openssl.bat
+++ b/windows/openssl/build_openssl.bat
@@ -18,3 +18,4 @@ if "%VSVERSION%" == "2010" (
         CALL C:\scripts\build_openssl_win64_2015.bat
     )
 )
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/windows/openssl/build_openssl_win32_2010.bat
+++ b/windows/openssl/build_openssl_win32_2010.bat
@@ -7,6 +7,7 @@ SET LIB=%LIB%;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1\Lib\
 
 perl Configure no-comp no-shared VC-WIN32
 nmake
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir C:\build\%FINALDIR%
 mkdir C:\build\%FINALDIR%\lib

--- a/windows/openssl/build_openssl_win32_2015.bat
+++ b/windows/openssl/build_openssl_win32_2015.bat
@@ -5,6 +5,7 @@ SET PATH=%PATH%;C:\Program Files\NASM
 
 perl Configure no-comp no-shared VC-WIN32
 nmake
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir C:\build\%FINALDIR%
 mkdir C:\build\%FINALDIR%\lib

--- a/windows/openssl/build_openssl_win64_2010.bat
+++ b/windows/openssl/build_openssl_win64_2010.bat
@@ -7,6 +7,7 @@ SET LIB=%LIB%;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1\Lib\x64
 
 perl Configure no-comp no-shared VC-WIN64A
 nmake
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir C:\build\%FINALDIR%
 mkdir C:\build\%FINALDIR%\lib

--- a/windows/openssl/build_openssl_win64_2015.bat
+++ b/windows/openssl/build_openssl_win64_2015.bat
@@ -5,6 +5,7 @@ SET PATH=%PATH%;C:\Program Files\NASM
 
 perl Configure no-comp no-shared VC-WIN64A
 nmake
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir C:\build\%FINALDIR%
 mkdir C:\build\%FINALDIR%\lib

--- a/windows/openssl/vs.bat
+++ b/windows/openssl/vs.bat
@@ -1,4 +1,4 @@
-curl -fSLo vs_BuildTools.exe https://aka.ms/vs/16/release/vs_buildtools.exe
+curl -fSLo vs_BuildTools.exe https://aka.ms/vs/15/release/vs_buildtools.exe
 if %errorlevel% neq 0 exit /b %errorlevel%
 setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 start /w vs_BuildTools.exe --quiet --norestart --nocache --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended


### PR DESCRIPTION
This is really just because we need nmake and previously we didn't have it so the CI passed by failing! So this also adds a bunch of error checking we didn't have previously (thanks cmd.exe)