### PR TITLE
Remove pymalloc build tag from python3.8 wheel

### DIFF
--- a/external-projects/cffi-wheel-builder.yml
+++ b/external-projects/cffi-wheel-builder.yml
@@ -90,7 +90,7 @@ jobs:
                   PYTHON_VERSION: 'cp36-cp36m'
               Python37m:
                   PYTHON_VERSION: 'cp37-cp37m'
-              Python38m:
+              Python38:
                   PYTHON_VERSION: 'cp38-cp38'
       steps:
           - script: /opt/python/$PYTHON_VERSION/bin/python -m virtualenv .venv

--- a/external-projects/cffi-wheel-builder.yml
+++ b/external-projects/cffi-wheel-builder.yml
@@ -91,7 +91,7 @@ jobs:
               Python37m:
                   PYTHON_VERSION: 'cp37-cp37m'
               Python38m:
-                  PYTHON_VERSION: 'cp38-cp38m'
+                  PYTHON_VERSION: 'cp38-cp38'
       steps:
           - script: /opt/python/$PYTHON_VERSION/bin/python -m virtualenv .venv
             displayName: Create virtualenv


### PR DESCRIPTION
From the 3.8 changelog:

> Default sys.abiflags became an empty string: the m flag for pymalloc became useless (builds with and without pymalloc are ABI compatible) and so has been removed. (Contributed by Victor Stinner in bpo-36707.)

