### PR TITLE
swap to ltsc2019 tag to try to gain some caching again

### DIFF
--- a/windows/openssl/Dockerfile
+++ b/windows/openssl/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809 as openssl-builder
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as openssl-builder
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/py27/Dockerfile
+++ b/windows/py27/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY --from=pyca/openssl-windows-artifact:win32-2010 "C:/openssl-win32-2010" C:/OpenSSL-Win32-2010
 COPY --from=pyca/openssl-windows-artifact:win64-2010 "C:/openssl-win64-2010" C:/OpenSSL-Win64-2010

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY --from=pyca/openssl-windows-artifact:win32-2015 "C:/openssl-win32-2015" C:/OpenSSL-Win32-2015
 COPY --from=pyca/openssl-windows-artifact:win64-2015 "C:/openssl-win64-2015" C:/OpenSSL-Win64-2015

--- a/windows/py34/Dockerfile
+++ b/windows/py34/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY --from=pyca/openssl-windows-artifact:win32-2010 "C:/openssl-win32-2010" C:/OpenSSL-Win32-2010
 COPY --from=pyca/openssl-windows-artifact:win64-2010 "C:/openssl-win64-2010" C:/OpenSSL-Win64-2010

--- a/windows/py35/Dockerfile
+++ b/windows/py35/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY --from=pyca/openssl-windows-artifact:win32-2015 "C:/openssl-win32-2015" C:/OpenSSL-Win32-2015
 COPY --from=pyca/openssl-windows-artifact:win64-2015 "C:/openssl-win64-2015" C:/OpenSSL-Win64-2015


### PR DESCRIPTION
this is just a whack-a-mole game we can never win.

we **don't** change the nanoserver from 1809 because **that** one is cached right now. Consistency!