### PR TITLE
build focal image, remove unused trusty, xenial, jessie

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -35,6 +35,7 @@ jobs:
           - {TAG_NAME: "pyca/cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bullseye"}
           - {TAG_NAME: "pyca/cryptography-runner-sid", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=sid"}
 
+          - {TAG_NAME: "pyca/cryptography-runner-ubuntu-bionic", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=bionic"}
           - {TAG_NAME: "pyca/cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=focal"}
           - {TAG_NAME: "pyca/cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling"}
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,14 +30,12 @@ jobs:
           - {TAG_NAME: "pyca/cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora"}
           - {TAG_NAME: "pyca/cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine"}
 
-          - {TAG_NAME: "pyca/cryptography-runner-jessie", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=jessie"}
           - {TAG_NAME: "pyca/cryptography-runner-stretch", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=stretch"}
           - {TAG_NAME: "pyca/cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=buster"}
           - {TAG_NAME: "pyca/cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bullseye"}
           - {TAG_NAME: "pyca/cryptography-runner-sid", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=sid"}
 
-          - {TAG_NAME: "pyca/cryptography-runner-ubuntu-trusty", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=trusty"}
-          - {TAG_NAME: "pyca/cryptography-runner-ubuntu-xenial", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=xenial"}
+          - {TAG_NAME: "pyca/cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=focal"}
           - {TAG_NAME: "pyca/cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling"}
 
           - {TAG_NAME: "pyca/cryptography-manylinux1:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux1"}

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get -qq update && apt-get install -qq -y \
 
 RUN if grep -q "sid" /etc/debian_version; then apt-get -qq update && apt-get install -qq -y python3-distutils python2-dev; else apt-get install -qq -y python-dev; fi
 
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python
+RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python3
 
 RUN pip install -q tox

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -16,13 +16,12 @@ RUN apt-get -qq update && apt-get install -qq -y \
     build-essential \
     libssl-dev \
     libffi-dev \
-    python-dev \
     python3-dev \
     git \
     curl \
     libenchant-dev
 
-RUN if grep -q "sid" /etc/debian_version; then apt-get -qq update && apt-get install -qq -y python3-distutils; fi
+RUN if grep -q "sid" /etc/debian_version; then apt-get -qq update && apt-get install -qq -y python3-distutils python2-dev; else apt-get install -qq -y python-dev; fi
 
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python
 


### PR DESCRIPTION
I've added the focal dockerhub repo. We can remove jessie/trusty/xenial after this merges. We do not use them in cryptography's CI any more.