### PR TITLE
Build Arm64 container for Manylinux2014_aarch64

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -18,6 +18,7 @@ on:
       - 'cryptography-manylinux/**'
 
 jobs:
+  # Build containers for x86
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -60,4 +61,44 @@ jobs:
         if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
       - name: Push image
         run: docker push ${{ matrix.IMAGE.TAG_NAME }}
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
+
+  # Build the manylinux2014_aarch64 container
+  build_manylinux2014_aarch64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        IMAGE:
+          - {TAG_NAME: "pyca/cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux2014_aarch64"}
+
+    name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
+    steps:
+      - uses: actions/checkout@master
+      - name: Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      # Pull the previous image, but if it fails return true anyway.
+      # Sometimes we add new docker images and if they've never been pushed
+      # they can't be pulled.
+      - name: Pull existing image
+        run: docker pull ${{ matrix.IMAGE.TAG_NAME }}:latest || true
+      - name: Build image
+        run: >
+          docker buildx build --platform linux/arm64 --pull --cache-from ${{ matrix.IMAGE.TAG_NAME }}
+          --cache-to "type=local,dest=/tmp/.buildx-cache" --output "type=image,push=false"
+          -t ${{ matrix.IMAGE.TAG_NAME }} ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }}
+      - name: Login to docker
+        run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
+      - name: Push image
+        run: >
+          docker buildx build --cache-from "type=local,src=/tmp/.buildx-cache"
+          --platform linux/arm64 --output "type=image,push=true" -t ${{ matrix.IMAGE.TAG_NAME }}
+          ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }}
         if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'

--- a/cryptography-manylinux/Dockerfile-manylinux2014_aarch64
+++ b/cryptography-manylinux/Dockerfile-manylinux2014_aarch64
@@ -1,0 +1,15 @@
+FROM quay.io/pypa/manylinux2014_aarch64
+MAINTAINER Python Cryptographic Authority
+WORKDIR /root
+# RUN yum -y install prelink && yum -y clean all
+RUN yum -y clean all
+ADD install_libffi.sh /root/install_libffi.sh
+RUN sh install_libffi.sh manylinux2014
+ADD install_openssl.sh /root/install_openssl.sh
+ADD openssl-version.sh /root/openssl-version.sh
+RUN sh install_openssl.sh manylinux2014
+ADD install_virtualenv.sh /root/install_virtualenv.sh
+RUN sh install_virtualenv.sh manylinux2014
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
Containers not supported Arm64
- Alpine Linux -- missing rustup precompiled binary on rust-lang site
- manylinux1 -- x86 only
- manylinux2010 -- x86 only

Remaining containers are built using buildx inside github actions to push a manifest to the docker repository to allow tags to contain multiple architectures.  Doing a `docker pull` on x86 or Arm64 machines will pull the expected container.

Tested in my own docker account and see all the containers with both x86 and arm64 hashes.