### PR TITLE
Include the architecture in the macOS OpenSSL artifact name

### DIFF
--- a/.github/workflows/build-macos-openssl.yml
+++ b/.github/workflows/build-macos-openssl.yml
@@ -46,5 +46,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2.2.0
         with:
-          name: "openssl-macos"
+          name: "openssl-macos-x86-64"
           path: artifact/


### PR DESCRIPTION
Will require an immediate follow up PR in pyca/cryptography