### PR TITLE
Don't install rust in the manylinux1 image

### DIFF
--- a/cryptography-manylinux/Dockerfile-manylinux1
+++ b/cryptography-manylinux/Dockerfile-manylinux1
@@ -14,6 +14,3 @@ ADD openssl-version.sh /root/openssl-version.sh
 RUN sh install_openssl.sh manylinux1
 ADD install_virtualenv.sh /root/install_virtualenv.sh
 RUN sh install_virtualenv.sh manylinux1
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
We won't be building manylinux1 images once we integrate rust, since recent rusts don't support glibc that old.