### PR TITLE
use diff openssldir on macOS for x86_64 and arm64

### DIFF
--- a/.github/workflows/build-macos-openssl.yml
+++ b/.github/workflows/build-macos-openssl.yml
@@ -25,9 +25,11 @@ jobs:
           - NAME: x86_64
             ARTIFACT_NAME: x86-64
             CFLAGS: "-mmacosx-version-min=10.10 -march=core2"
+            OPENSSLDIR: "/usr/local/etc/openssl@1.1" 
           - NAME: arm64
             ARTIFACT_NAME: arm64
             CFLAGS: "-mmacosx-version-min=11.0"
+            OPENSSLDIR: "/opt/homebrew/etc/openssl@1.1" 
     name: "Build OpenSSL for macOS (${{ matrix.ARCH.NAME }})"
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +53,7 @@ jobs:
           # an imperfect world.
           perl ./Configure \
               --prefix="${BASEDIR}/artifact" \
-              --openssldir=/usr/local/etc/openssl@1.1 \
+              --openssldir=${{ matrix.ARCH.OPENSSLDIR }} \
               darwin64-${{ matrix.ARCH.NAME }}-cc \
               $OPENSSL_BUILD_FLAGS
           make -j$(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
Homebrew's plan is to switch to /opt/homebrew for arm64 macOS.