### PR TITLE
add manylinux2014 x86-64 image

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -42,6 +42,7 @@ jobs:
 
           - {TAG_NAME: "cryptography-manylinux1:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux1"}
           - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux2010"}
+          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux2014"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/cryptography-manylinux/Dockerfile-manylinux2014
+++ b/cryptography-manylinux/Dockerfile-manylinux2014
@@ -1,0 +1,14 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+MAINTAINER Python Cryptographic Authority
+WORKDIR /root
+RUN yum -y install prelink && yum -y clean all
+ADD install_libffi.sh /root/install_libffi.sh
+RUN sh install_libffi.sh manylinux2014
+ADD install_openssl.sh /root/install_openssl.sh
+ADD openssl-version.sh /root/openssl-version.sh
+RUN sh install_openssl.sh manylinux2014
+ADD install_virtualenv.sh /root/install_virtualenv.sh
+RUN sh install_virtualenv.sh manylinux2014
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
We're now not far from dropping manylinux1. We should start doing manylinux2014 builds to see what percentage of our users have pip new enough to pull that.

Separately we should consider advocating that pip put in logic for manylinux2019 now even though the spec hasn't been defined and won't be for awhile specifically to get ahead of this tag issue.