### PR TITLE
switch to searching on os-release

### DIFF
--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get -qq update && apt-get install -qq -y \
     curl
 
 # Remove when we drop 2.7 support from pyOpenSSL
-RUN apt-get -qq update; if grep -q "stretch" /etc/debian_version; then apt-get install -qq -y python-dev; fi
-RUN apt-get -qq update; if grep -q "sid" /etc/debian_version; then apt-get install -qq -y python3-distutils; fi
+RUN apt-get -qq update; if grep -q "stretch" /etc/os-release; then apt-get install -qq -y python-dev; fi
+RUN apt-get -qq update; if grep -q "sid" /etc/os-release; then apt-get install -qq -y python3-distutils; fi
 
 # Remove /3.5/ when we drop stretch!
 RUN curl -sSL https://bootstrap.pypa.io/3.5/get-pip.py | python3

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -qq update; if grep -q "stretch" /etc/os-release; then apt-get insta
 RUN apt-get -qq update; if grep -q "sid" /etc/os-release; then apt-get install -qq -y python3-distutils; fi
 
 # Remove /3.5/ when we drop stretch!
-RUN curl -sSL https://bootstrap.pypa.io/3.5/get-pip.py | python3
+RUN curl -sSL https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3
 
 RUN pip install tox coverage
 


### PR DESCRIPTION
Once a debian version is released `/etc/debian_release` contains a version, so the `stretch` search here always returned false.