### PR TITLE
Expose `RELEASE` build env var in the stage scope

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -40,9 +40,9 @@ jobs:
           - {TAG_NAME: "cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=focal"}
           - {TAG_NAME: "cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling"}
 
-          - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2010_x86_64"}
-          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2014_x86_64"}
-          - {TAG_NAME: "cryptography-manylinux_2_24:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_x86_64"}
+          - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux2010_x86_64"}
+          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux2014_x86_64"}
+          - {TAG_NAME: "cryptography-manylinux_2_24:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux_2_24_x86_64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:
@@ -71,8 +71,8 @@ jobs:
     strategy:
       matrix:
         IMAGE:
-          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2014_aarch64"}
-          - {TAG_NAME: "cryptography-manylinux_2_24:aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_aarch64"}
+          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux2014_aarch64"}
+          - {TAG_NAME: "cryptography-manylinux_2_24:aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux_2_24_aarch64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -1,5 +1,6 @@
 ARG RELEASE
 FROM quay.io/pypa/${RELEASE}
+ARG RELEASE  # https://github.com/pyca/infra/issues/338
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
 RUN \

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -1,6 +1,6 @@
-ARG RELEASE
-FROM quay.io/pypa/${RELEASE}
-ARG RELEASE  # https://github.com/pyca/infra/issues/338
+ARG PYCA_RELEASE
+FROM quay.io/pypa/${PYCA_RELEASE}
+ARG PYCA_RELEASE
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
 RUN \

--- a/cryptography-manylinux/install_openssl.sh
+++ b/cryptography-manylinux/install_openssl.sh
@@ -1,19 +1,6 @@
 #!/bin/bash
 set -xe
 
-# IMPORTANT:
-# The underlying build scripts of OpenSSL rely on the `${RELEASE}`
-# environment variable and if it's suddenly available in the env,
-# it goes crazy when the value is illegal.
-# 
-# It errors out with the following message:
-# 
-#   Operating system: x86_64-whatever-Linux
-#   This system (Linux) is not supported. See file INSTALL for details.
-# 
-# Ref: https://github.com/pyca/infra/issues/338
-unset RELEASE
-
 OPENSSL_URL="https://www.openssl.org/source/"
 source /root/openssl-version.sh
 

--- a/cryptography-manylinux/install_openssl.sh
+++ b/cryptography-manylinux/install_openssl.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -xe
 
+# IMPORTANT:
+# The underlying build scripts of OpenSSL rely on the `${RELEASE}`
+# environment variable and if it's suddenly available in the env,
+# it goes crazy when the value is illegal.
+# 
+# It errors out with the following message:
+# 
+#   Operating system: x86_64-whatever-Linux
+#   This system (Linux) is not supported. See file INSTALL for details.
+# 
+# Ref: https://github.com/pyca/infra/issues/338
+unset RELEASE
+
 OPENSSL_URL="https://www.openssl.org/source/"
 source /root/openssl-version.sh
 


### PR DESCRIPTION
The instruction `ARG RELEASE` was only present before the `FROM` line
making it out of scope. This change exposes it to the main image
build stage.

Note that this change makes the `${RELEASE}` env var available in the
runtime of each `RUN` instruction which may cause unintended
side-effects whenever any underlying tooling depends on the value in
this variable.

It is known that the underlying build scripts of OpenSSL rely on the
`${RELEASE}` environment variable and if it's suddenly available in
the env, it goes crazy when the value is illegal.

In particular, it errors out with the following message:

```console
Operating system: x86_64-whatever-Linux
This system (Linux) is not supported. See file INSTALL for details.
```

This is why the change is accompanied with `unset RELEASE` patches to
the main build scripts.

Fixes https://github.com/pyca/infra/issues/338