### PR TITLE
Add `manylinux_2_24` images to the build matrix

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         IMAGE:
           - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2014_aarch64"}
-          - {TAG_NAME: "cryptography-manylinux_2_24_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_aarch64"}
+          - {TAG_NAME: "cryptography-manylinux_2_24:aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_aarch64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -42,6 +42,7 @@ jobs:
 
           - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2010_x86_64"}
           - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2014_x86_64"}
+          - {TAG_NAME: "cryptography-manylinux_2_24:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_x86_64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:
@@ -64,13 +65,14 @@ jobs:
         run: docker push ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }}
         if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
 
-  # Build the manylinux2014_aarch64 container
-  build_manylinux2014_aarch64:
+  # Build the manylinux*_aarch64 containers
+  build_manylinux_aarch64:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         IMAGE:
           - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux2014_aarch64"}
+          - {TAG_NAME: "cryptography-manylinux_2_24_aarch64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg RELEASE=manylinux_2_24_aarch64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -18,10 +18,10 @@ RUN \
     fi; \
   fi
 ADD install_libffi.sh /root/install_libffi.sh
-RUN sh install_libffi.sh
+RUN ./install_libffi.sh
 ADD install_openssl.sh /root/install_openssl.sh
 ADD openssl-version.sh /root/openssl-version.sh
-RUN sh install_openssl.sh
+RUN ./install_openssl.sh
 
 # Install PyPy
 RUN if [ $(uname -m) = "x86_64" ]; then curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && mv /opt/pypy3.6* /opt/pypy3.6; fi

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -2,7 +2,21 @@ ARG RELEASE
 FROM quay.io/pypa/${RELEASE}
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
-RUN if [ $(uname -m) = "x86_64" ]; then yum -y install prelink && yum -y clean all; fi
+RUN \
+  if [ $(uname -m) = "x86_64" ]; \
+  then \
+    if stat /etc/redhat-release 1>&2 2>/dev/null; then \
+      yum -y install prelink && \
+      yum -y clean all && \
+      rm -rf /var/cache/yum; \
+    else \
+      export DEBIAN_FRONTEND=noninteractive && \
+      apt-get update -qq && \
+      apt-get install -qq -y --no-install-recommends prelink && \
+      apt-get clean -qq && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi; \
+  fi
 ADD install_libffi.sh /root/install_libffi.sh
 RUN sh install_libffi.sh
 ADD install_openssl.sh /root/install_openssl.sh

--- a/cryptography-manylinux/install_libffi.sh
+++ b/cryptography-manylinux/install_libffi.sh
@@ -16,7 +16,7 @@ curl -#O "https://mirrors.ocf.berkeley.edu/debian/pool/main/libf/libffi/libffi_$
 check_sha256sum "libffi_${LIBFFI_VERSION}.orig.tar.gz" ${LIBFFI_SHA256}
 tar zxf libffi*.orig.tar.gz
 PATH=/opt/perl/bin:$PATH
-pushd libffi*
+pushd libffi*/
 ./configure CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security"
 make install
 popd


### PR DESCRIPTION
`manylinux1/2010/2014` are CentOS-based but `2_24` runs Debian 9.
This is why this patch switches over to using APT conditionally
to install `prelink` with an OS-specific package manager.

Also, this change resorts to calling the executable scripts
directly letting the runtime consult with the shebang and use the
appropriate interpreter.

Old CentOS-based images have `sh` pointing to `bash` while in Debian
it actually points to `sh`. This is a side-effect that the old image
used to rely on and it does not work anymore for `manylinux_2_24`.

One way would be to change `s/sh/bash` in the dockerfile but I chose
to rely on the existing shebang comments that already point to it but
are ignored when the interpreter is stated explicitly.

Fixes #339