### PR TITLE
preparations for musllinux

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -43,6 +43,7 @@ jobs:
           - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux2010_x86_64"}
           - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux2014_x86_64"}
           - {TAG_NAME: "cryptography-manylinux_2_24:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=manylinux_2_24_x86_64"}
+          - {TAG_NAME: "cryptography-musllinux_1_1:x86_64", DOCKERFILE_PATH: "cryptography-manylinux", BUILD_ARGS: "-f cryptography-manylinux/Dockerfile-manylinux --build-arg PYCA_RELEASE=musllinux_1_1_x86_64"}
 
     name: "Building docker image ${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -10,7 +10,7 @@ RUN \
       yum -y install prelink && \
       yum -y clean all && \
       rm -rf /var/cache/yum; \
-    else \
+    elif stat /etc/debian_version 1>&2 2>/dev/null; then \
       export DEBIAN_FRONTEND=noninteractive && \
       apt-get update -qq && \
       apt-get install -qq -y --no-install-recommends prelink && \
@@ -28,7 +28,7 @@ RUN \
       yum -y install libffi-devel && \
       yum -y clean all && \
       rm -rf /var/cache/yum; \
-    else \
+    elif stat /etc/debian_version 1>&2 2>/dev/null; then \
       export DEBIAN_FRONTEND=noninteractive && \
       apt-get update -qq && \
       apt-get install -qq -y --no-install-recommends libffi-dev && \
@@ -42,8 +42,20 @@ ADD openssl-version.sh /root/openssl-version.sh
 RUN ./install_openssl.sh
 
 # Install PyPy
-RUN if [ $(uname -m) = "x86_64" ]; then curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && mv /opt/pypy3.6* /opt/pypy3.6; fi
-RUN if [ $(uname -m) = "x86_64" ]; then curl https://downloads.python.org/pypy/pypy3.7-v7.3.4-linux64.tar.bz2 | tar jxf - -C /opt/ && mv /opt/pypy3.7* /opt/pypy3.7; fi
+RUN \
+  if [ $(uname -m) = "x86_64" ]; then \
+    if stat /etc/alpine-release 1>&2 2>/dev/null; then \
+      echo 'There are no prebuilt musl pypy so we are just gonna fake it till someone else makes it'; \
+      mkdir -p /opt/pypy3.6/bin /opt/pypy3.7/bin; \
+      ln -s /opt/python/cp36-cp36m/bin/python /opt/pypy3.6/bin/pypy; \
+      ln -s /opt/python/cp37-cp37m/bin/python /opt/pypy3.7/bin/pypy; \
+    else \
+      curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && \
+        mv /opt/pypy3.6* /opt/pypy3.6; \
+      curl https://downloads.python.org/pypy/pypy3.7-v7.3.4-linux64.tar.bz2 | tar jxf - -C /opt/ && \
+        mv /opt/pypy3.7* /opt/pypy3.7; \
+    fi; \
+  fi
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/cryptography-manylinux/Dockerfile-manylinux
+++ b/cryptography-manylinux/Dockerfile-manylinux
@@ -16,6 +16,8 @@ RUN \
       apt-get install -qq -y --no-install-recommends prelink && \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
+    else \
+      echo "This is alpine and we don't need any more packages"; \
     fi; \
   fi
 
@@ -34,6 +36,8 @@ RUN \
       apt-get install -qq -y --no-install-recommends libffi-dev && \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
+    else \
+      echo "This is alpine and we don't need any more packages"; \
     fi; \
   fi
 
@@ -45,10 +49,7 @@ RUN ./install_openssl.sh
 RUN \
   if [ $(uname -m) = "x86_64" ]; then \
     if stat /etc/alpine-release 1>&2 2>/dev/null; then \
-      echo 'There are no prebuilt musl pypy so we are just gonna fake it till someone else makes it'; \
-      mkdir -p /opt/pypy3.6/bin /opt/pypy3.7/bin; \
-      ln -s /opt/python/cp36-cp36m/bin/python /opt/pypy3.6/bin/pypy; \
-      ln -s /opt/python/cp37-cp37m/bin/python /opt/pypy3.7/bin/pypy; \
+      echo 'Skip building musl PyPy wheels for now'; \
     else \
       curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && \
         mv /opt/pypy3.6* /opt/pypy3.6; \


### PR DESCRIPTION
This should get everything going once musllinux is available from https://github.com/pypa/manylinux/pull/1135
I should caveat this PR by saying that afaik this is my first day touching anything in the python ecosystem so apologies if this is dumb lol

Also I kinda anticipate the pypy shuffling in cryptography-manylinux/Dockerfile-manylinux will not pass review but I included it in the off chance no one cares (why is pypy used in the pyca/cryptography builds?) or if any one wants to test building Alpine cryptography wheels with musllinux. Here's how I did that:
```shell
git clone git@github.com:pypa/manylinux
pushd manylinux
MANYLINUX_BUILD_FRONTEND=docker POLICY="musllinux_1_1" PLATFORM="x86_64" COMMIT_SHA="HEAD" ./build.sh
popd
git clone git@github.com:pyca/infra
pushd infra
docker build -f cryptography-manylinux/Dockerfile-manylinux -t ghcr.io/pyca/cryptography-musllinux_1_1:x86_64 --build-arg PYCA_RELEASE=musllinux_1_1_x86_64:HEAD .
pushd $(mktemp -d)
# essentially identical build to cryptography's wheel-builder.yml, except for pulling auditwheel@5 from git
curl -s 'https://gist.githubusercontent.com/Liath/83636c9001f65d6b8c03a2da3f4f5fa8/raw/99dfa9ed53db0e940bef24b0f2266994b77d2cf5/Dockerfile' -o Dockerfile
docker build -t pyca-cryptography-musllinux --build-arg CRYPTOGRAPHY_VERSION=3.4.8 .
```
