### PR TITLE
Add PyPy 3.8 and bump PyPy 3.7 version

### DIFF
--- a/cryptography-linux/Dockerfile-linux
+++ b/cryptography-linux/Dockerfile-linux
@@ -53,8 +53,10 @@ RUN \
     else \
       curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && \
         mv /opt/pypy3.6* /opt/pypy3.6; \
-      curl https://downloads.python.org/pypy/pypy3.7-v7.3.4-linux64.tar.bz2 | tar jxf - -C /opt/ && \
+      curl https://downloads.python.org/pypy/pypy3.7-v7.3.6-linux64.tar.bz2 | tar jxf - -C /opt/ && \
         mv /opt/pypy3.7* /opt/pypy3.7; \
+      curl https://downloads.python.org/pypy/pypy3.8-v7.3.6-linux64.tar.bz2 | tar jxf - -C /opt/ && \
+        mv /opt/pypy3.8* /opt/pypy3.8; \
     fi; \
   fi
 


### PR DESCRIPTION
I added PyPy 3.8 so that wheels for said PyPy version can be built for it for cryptography (or so I think? I'm not great at this packaging stuff).

While doing that, I noticed the version for PyPy 3.7 was outdated, and although I don't know if it makes a difference, I followed the example of #353.