### PR TITLE
build centos stream containers (including fips variant)

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -26,8 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE:
-          - {TAG_NAME: "cryptography-runner-rhel8", DOCKERFILE_PATH: "runners/rhel8"}
-          - {TAG_NAME: "cryptography-runner-rhel8-fips", DOCKERFILE_PATH: "runners/rhel8", BUILD_ARGS: "--build-arg FIPS=1"}
+          - {TAG_NAME: "cryptography-runner-rhel8", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg RELEASE=redhat/ubi8"}
+          - {TAG_NAME: "cryptography-runner-rhel8-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=redhat/ubi8"}
+          - {TAG_NAME: "cryptography-runner-centos-stream9", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg RELEASE=quay.io/centos/centos:stream9"}
+          - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=quay.io/centos/centos:stream9"}
 
           - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora"}
           - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine"}
@@ -39,6 +41,7 @@ jobs:
 
           - {TAG_NAME: "cryptography-runner-ubuntu-bionic", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=bionic"}
           - {TAG_NAME: "cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=focal"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-jammy", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=jammy"}
           - {TAG_NAME: "cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling"}
 
           - {TAG_NAME: "cryptography-manylinux2010:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "-f cryptography-linux/Dockerfile-linux --build-arg PYCA_RELEASE=manylinux2010_x86_64"}

--- a/runners/rhel/Dockerfile
+++ b/runners/rhel/Dockerfile
@@ -1,9 +1,10 @@
-FROM redhat/ubi8
+ARG RELEASE
+FROM ${RELEASE}
 ARG FIPS
 
 RUN yum install -y gcc libffi-devel python3-devel openssl-devel git which pkg-config
 
-RUN if [ "$FIPS" = "1" ] ; then touch /etc/system-fips && echo "FIPS mode"; else echo "Not FIPS mode"; fi
+RUN if [ "$FIPS" = "1" ] ; then rm -rf /etc/system-fips && touch /etc/system-fips && echo "FIPS mode"; else echo "Not FIPS mode"; fi
 
 RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
 


### PR DESCRIPTION
These containers can replace rhel8 when we drop 3.6, although right now they demonstrate two bugs in Red Hat's OpenSSL patches (see: https://github.com/pyca/cryptography/issues/6962)