### PR TITLE
Stop pre-installing tox and coverage into docker containers

### DIFF
--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 RUN apk add --no-cache git libffi-dev curl \
     python3-dev openssl-dev bash gcc musl-dev tar pkgconfig
 
-RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
+RUN python3 -m venv /venv
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -qq update && apt-get install -qq -y \
     curl \
     pkg-config
 
-RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
+RUN python3 -m venv /venv
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/fedora/Dockerfile
+++ b/runners/fedora/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG C.UTF-8
 RUN dnf install -y gcc redhat-rpm-config libffi-devel python3 \
     python3-devel openssl-devel git findutils which pkg-config
 
-RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
+RUN python3 -m venv /venv
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/rhel/Dockerfile
+++ b/runners/rhel/Dockerfile
@@ -8,7 +8,7 @@ RUN if [ "$RELEASE" = "redhat/ubi8" ] ; then yum install -y python38-devel; fi
 
 RUN if [ "$FIPS" = "1" ] ; then rm -rf /etc/system-fips && touch /etc/system-fips && echo "FIPS mode"; else echo "Not FIPS mode"; fi
 
-RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
+RUN python3 -m venv /venv
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/ubuntu/Dockerfile
+++ b/runners/ubuntu/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -qq update && apt-get install -qq -y \
     tzdata \
     pkg-config
 
-RUN python3 -m venv /venv && /venv/bin/pip install tox coverage
+RUN python3 -m venv /venv
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
Install it at test-time so we can pin versions