### PR TITLE
terraform fixes

### DIFF
--- a/terraform/cloudinit.tf
+++ b/terraform/cloudinit.tf
@@ -6,9 +6,20 @@ data "cloudinit_config" "worker" {
   part {
     filename     = "worker.sh"
     content_type = "text/x-shellscript"
+    # https://github.com/oracle-terraform-modules/terraform-oci-oke/blob/9561e1ac70460335ae9e6d03ab73d503185d1d78/modules/oke/cloudinit/worker.template.sh
     content      = <<-EOT
-      #!/bin/bash
-      /usr/libexec/oci-growfs -y
+        #!/bin/bash
+
+        # DO NOT MODIFY
+        curl --fail -H "Authorization: Bearer Oracle" -L0 http://169.254.169.254/opc/v2/instance/metadata/oke_init_script | base64 --decode >/var/run/oke-init.sh
+
+        ## run oke provisioning script
+        bash -x /var/run/oke-init.sh
+
+        ### adjust block volume size
+        /usr/libexec/oci-growfs -y
+
+        touch /var/log/oke.done
     EOT
   }
 

--- a/terraform/helm.tf
+++ b/terraform/helm.tf
@@ -8,7 +8,7 @@ resource "helm_release" "cm" {
   values = [<<EOF
     global:
       podSecurityPolicy:
-        enabled: true
+        enabled: false
         useAppArmor: true
     prometheus:
       enabled: false


### PR DESCRIPTION
This properly provisions new worker nodes and resizes the partition and disables the pod security policy in cert-manager that didn't do anything anyway since it's deprecated and removed in k8s 1.25+.

An upcoming PR will migrate us to k8s 1.25.x