### PR TITLE
On RHEL8, create the venv with python 3.8

### DIFF
--- a/runners/rhel/Dockerfile
+++ b/runners/rhel/Dockerfile
@@ -8,7 +8,7 @@ RUN if [ "$RELEASE" = "redhat/ubi8" ] ; then yum install -y python38-devel; fi
 
 RUN if [ "$FIPS" = "1" ] ; then rm -rf /etc/system-fips && touch /etc/system-fips && echo "FIPS mode"; else echo "Not FIPS mode"; fi
 
-RUN python3 -m venv /venv
+RUN if [ "$RELEASE" = "redhat/ubi8" ] ; then python3.8 -m venv /venv; else python3 -m venv /venv; fi
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
this means tox will be installed with python 3.8, doesn't affect how tests are run