### PR TITLE
Install llvm-tools-preview in some of the Docker containers

### DIFF
--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -12,5 +12,5 @@ RUN apk add --no-cache git libffi-dev curl \
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -23,5 +23,5 @@ RUN apt-get -qq update && apt-get install -qq -y \
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/ubuntu/Dockerfile
+++ b/runners/ubuntu/Dockerfile
@@ -26,5 +26,5 @@ RUN apt-get -qq update && apt-get install -qq -y \
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
 ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
But only the ones where _this_ is the current failure in https://github.com/pyca/cryptography/pull/8936, there's other that require more debugging (and which I'll eventually send a follow-up PR here for)