### PR TITLE
Revert "use gcompat from source to work around lack of fcntl64 release"

### DIFF
--- a/cryptography-linux/Dockerfile
+++ b/cryptography-linux/Dockerfile
@@ -17,12 +17,7 @@ RUN \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
     else \
-      # alpine
-      git clone https://git.adelielinux.org/adelie/gcompat && \
-      cd gcompat && \
-      make && \
-      make install && \
-      cd .. && rm -rf gcompat; \
+      echo "This is alpine and we don't need any more packages"; \
     fi; \
   fi
 
@@ -42,12 +37,12 @@ RUN \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
     else \
-      # alpine
-      git clone https://git.adelielinux.org/adelie/gcompat && \
-      cd gcompat && \
-      make && \
-      make install && \
-      cd .. && rm -rf gcompat; \
+      # musllinux_1_1 ships with gcompat 0.4 which is too old. Commit computer crimes
+      # by adding a newer gcompat to an old alpine so that our GH actions will work.
+      # Your laptop is not waterproof so please turn away lest your tears damage it.
+      echo "http://dl-cdn.alpinelinux.org/alpine/v3.17/main" >> /etc/apk/repositories && \
+      echo "http://dl-cdn.alpinelinux.org/alpine/v3.17/community" >> /etc/apk/repositories && \
+      apk add --no-cache gcompat; \
     fi; \
   fi
 

--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -7,10 +7,8 @@ ENV CACHE_BUSTER 1
 # "ANSI_X3.4-1968".
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache git libffi-dev curl make \
-    python3-dev openssl-dev bash gcc musl-dev tar pkgconfig zstd
-
-RUN git clone https://git.adelielinux.org/adelie/gcompat && cd gcompat && make && make install && cd .. && rm -rf gcompat
+RUN apk add --no-cache git libffi-dev curl \
+    python3-dev openssl-dev bash gcc musl-dev tar pkgconfig gcompat zstd
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 


### PR DESCRIPTION
Reverts pyca/infra#545