### PR TITLE
build static node.js for manylinux2014 x86_64 and arm64

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -36,7 +36,6 @@ jobs:
           - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
 
           - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", RUNNER: "ubuntu-latest"}
-          # TODO
           - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
 
           - {TAG_NAME: "cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=buster", RUNNER: "ubuntu-latest"}
@@ -60,7 +59,6 @@ jobs:
           - {TAG_NAME: "cryptography-musllinux_1_1:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
           - {TAG_NAME: "cryptography-musllinux_1_2:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
           - {TAG_NAME: "cryptography-runner-ubuntu-rolling:aarch64", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: [self-hosted, Linux, ARM64]}
-          # TODO
           - {TAG_NAME: "cryptography-runner-alpine:aarch64", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
 
     name: "${{ matrix.IMAGE.TAG_NAME }}"

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -71,7 +71,7 @@ jobs:
         run: docker pull ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} || true
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
       - name: Build image
-        run: docker build --pull --cache-from ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} -t ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }} --build-arg NODE_ARCH_RELEASE=${{ matrix.NODE_ARCH }}:v20.13.1
+        run: docker build --pull --cache-from ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} -t ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }} --build-arg NODE_ARCH_RELEASE=${{ matrix.IMAGE.NODE_ARCH }}:v20.13.1
       - name: Login to docker
         run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'
         env:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -36,7 +36,8 @@ jobs:
           - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
 
           - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", RUNNER: "ubuntu-latest"}
+          # TODO
+          - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
 
           - {TAG_NAME: "cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=buster", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bullseye", RUNNER: "ubuntu-latest"}
@@ -49,17 +50,18 @@ jobs:
           - {TAG_NAME: "cryptography-runner-ubuntu-noble", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=noble", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_x86_64", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-manylinux_2_28:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_x86_64", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-musllinux_1_1:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_x86_64", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-musllinux_1_2:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_x86_64", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-manylinux_2_28:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-musllinux_1_1:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-musllinux_1_2:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-manylinux_2_28:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-musllinux_1_1:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-musllinux_1_2:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-manylinux_2_28:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-musllinux_1_1:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-musllinux_1_2:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
           - {TAG_NAME: "cryptography-runner-ubuntu-rolling:aarch64", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-runner-alpine:aarch64", DOCKERFILE_PATH: "runners/alpine", RUNNER: [self-hosted, Linux, ARM64]}
+          # TODO
+          - {TAG_NAME: "cryptography-runner-alpine:aarch64", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
 
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,36 +30,36 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE:
-          - {TAG_NAME: "cryptography-runner-rhel8", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg RELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-rhel8-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-centos-stream9", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-rhel8", DOCKERFILE_PATH: "runners/rhel", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-rhel8-fips", DOCKERFILE_PATH: "runners/rhel", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-centos-stream9", DOCKERFILE_PATH: "runners/rhel", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg FIPS=1 --build-arg RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", NODE_ARCH: "x64", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", NODE_ARCH: "x64", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=buster", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bullseye", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-bookworm", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bookworm", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-trixie", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=trixie", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-sid", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=sid", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=buster", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=bullseye", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-bookworm", DOCKERFILE_PATH: "runners/debian", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=bookworm", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-trixie", DOCKERFILE_PATH: "runners/debian", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=trixie", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-sid", DOCKERFILE_PATH: "runners/debian", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=sid", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=focal", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-ubuntu-jammy", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=jammy", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-ubuntu-noble", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=noble", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-focal", DOCKERFILE_PATH: "runners/ubuntu", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=focal", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-jammy", DOCKERFILE_PATH: "runners/ubuntu", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=jammy", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-noble", DOCKERFILE_PATH: "runners/ubuntu", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=noble", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-rolling", DOCKERFILE_PATH: "runners/ubuntu", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-manylinux_2_28:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-musllinux_1_1:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-musllinux_1_2:x86_64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_x86_64 --build-arg NODE_ARCH_RELEASE=x64:v20.13.1", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-manylinux2014:x86_64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_x86_64", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-manylinux_2_28:x86_64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_x86_64", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-musllinux_1_1:x86_64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_x86_64", RUNNER: "ubuntu-latest"}
+          - {TAG_NAME: "cryptography-musllinux_1_2:x86_64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "x64", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_x86_64", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-manylinux_2_28:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-musllinux_1_1:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-musllinux_1_2:aarch64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_aarch64 --build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-runner-ubuntu-rolling:aarch64", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: [self-hosted, Linux, ARM64]}
-          - {TAG_NAME: "cryptography-runner-alpine:aarch64", DOCKERFILE_PATH: "runners/alpine", BUILD_ARGS: "--build-arg NODE_ARCH_RELEASE=arm64:v20.13.1", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-manylinux2014_aarch64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "arm64", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux2014_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-manylinux_2_28:aarch64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "arm64", BUILD_ARGS: "--build-arg PYCA_RELEASE=manylinux_2_28_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-musllinux_1_1:aarch64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "arm64", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_1_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-musllinux_1_2:aarch64", DOCKERFILE_PATH: "cryptography-linux", NODE_ARCH: "arm64", BUILD_ARGS: "--build-arg PYCA_RELEASE=musllinux_1_2_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-runner-ubuntu-rolling:aarch64", DOCKERFILE_PATH: "runners/ubuntu", NODE_ARCH: "arm64", BUILD_ARGS: "--build-arg RELEASE=rolling", RUNNER: [self-hosted, Linux, ARM64]}
+          - {TAG_NAME: "cryptography-runner-alpine:aarch64", DOCKERFILE_PATH: "runners/alpine", NODE_ARCH: "arm64", RUNNER: [self-hosted, Linux, ARM64]}
 
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:
@@ -71,7 +71,7 @@ jobs:
         run: docker pull ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} || true
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
       - name: Build image
-        run: docker build --pull --cache-from ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} -t ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }}
+        run: docker build --pull --cache-from ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} -t ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }} ${{ matrix.IMAGE.DOCKERFILE_PATH }} ${{ matrix.IMAGE.BUILD_ARGS }} --build-arg NODE_ARCH_RELEASE=${{ matrix.NODE_ARCH }}:v20.13.1
       - name: Login to docker
         run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'
         env:

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -33,19 +33,17 @@ jobs:
         echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
     - name: Build the Docker image
       run: |
-         echo building node.js $NODE_VERSION
-         docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.ARCH  }} staticnode
+        echo building node.js $NODE_VERSION
+        docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.ARCH  }} staticnode
     - name: Copy static node.js out
       run: |
-         mkdir $RUNNER_TEMP/static_node
-         docker run --rm -v $RUNNER_TEMP/static_node:/node_output ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION cp -v -a /node_staging/. /node_output/
-         ls -l -R $RUNNER_TEMP/static_node
+        mkdir $RUNNER_TEMP/static_node
+        docker run --rm -v $RUNNER_TEMP/static_node:/node_output ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION cp -R -v -a /* /node_output/
+        ls -l -R $RUNNER_TEMP/static_node
+
     - name: Test that it works
       run: |
-        mkdir $RUNNER_TEMP/test
-        cd $RUNNER_TEMP/test
-        tar xzf $RUNNER_TEMP/static_node/node-$NODE_VERSION-static-${{ matrix.IMAGE.ARCH }}.tar.gz
-        ls -l -R
+        cd $RUNNER_TEMP/static_node
         ./bin/node -v
         ./bin/node -e "console.log('hello world')"
         uname -a

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -1,0 +1,60 @@
+name: Build and Release Static Node.js
+permissions:
+  contents: read
+  packages: write
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/build-static-node.yml'
+      - 'staticnode/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-static-node.yml'
+      - 'staticnode/**'
+
+jobs:
+  build:
+    name: Build node.js
+    runs-on: ${{ matrix.IMAGE.RUNNER }}
+    strategy:
+      fail-fast: false
+      matrix:
+        IMAGE:
+          - {RUNNER: "ubuntu-latest", ARCH: "x64", TAG_NAME: "static-nodejs-x64"}
+          - {RUNNER: [self-hosted, Linux, ARM64], ARCH: "arm64", TAG_NAME: "static-nodejs-arm64"}
+    steps:
+    - uses: actions/checkout@v4.1.5
+    - name: Set Node.js version
+      run: |
+        source ./staticnode/node-version.sh
+        echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
+    - name: Build the Docker image
+      run: |
+         echo building node.js $NODE_VERSION
+         docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.ARCH  }} staticnode
+    - name: Copy static node.js out
+      run: |
+         mkdir $RUNNER_TEMP/static_node
+         docker run --rm -v $RUNNER_TEMP/static_node:/node_output ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION cp -v -a /node_staging/. /node_output/
+         ls -l -R $RUNNER_TEMP/static_node
+    - name: Test that it works
+      run: |
+        mkdir $RUNNER_TEMP/test
+        cd $RUNNER_TEMP/test
+        tar xzf $RUNNER_TEMP/static_node/node-$NODE_VERSION-static-${{ matrix.IMAGE.ARCH }}.tar.gz
+        ls -l -R
+        ./bin/node -v
+        ./bin/node -e "console.log('hello world')"
+        uname -a
+    - name: Login to docker
+      run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'
+      env:
+        DOCKER_USERNAME: ${{ github.actor }}
+        DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    - name: Push image
+      run: docker push ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }}:${{ env.NODE_VERSION }}
+      if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -1,4 +1,4 @@
-name: Build and Release Static Node.js
+name: Build Static Node.js Container
 permissions:
   contents: read
   packages: write
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE:
-          - {RUNNER: "ubuntu-latest", ARCH: "x64", TAG_NAME: "static-nodejs-x64"}
-          - {RUNNER: [self-hosted, Linux, ARM64], ARCH: "arm64", TAG_NAME: "static-nodejs-arm64"}
+          - {RUNNER: "ubuntu-latest", ARCH: "x64"}
+          - {RUNNER: [self-hosted, Linux, ARM64], ARCH: "arm64"}
     steps:
     - uses: actions/checkout@v4.1.5
     - name: Set Node.js version
@@ -56,5 +56,5 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     - name: Push image
-      run: docker push ghcr.io/pyca/${{ matrix.IMAGE.TAG_NAME }}:${{ env.NODE_VERSION }}
+      run: docker push ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:${{ env.NODE_VERSION }}
       if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE:
-          - {RUNNER: "ubuntu-latest", ARCH: "x64"}
-          - {RUNNER: [self-hosted, Linux, ARM64], ARCH: "arm64"}
+          - {RUNNER: "ubuntu-latest", NODE_ARCH: "x64", MANYLINUX_ARCH: "x86_64"}
+          - {RUNNER: [self-hosted, Linux, ARM64], NODE_ARCH: "arm64", MANYLINUX_ARCH: "aarch64"}
     steps:
     - uses: actions/checkout@v4.1.5
     - name: Set Node.js version
@@ -34,19 +34,11 @@ jobs:
     - name: Build the Docker image
       run: |
         echo building node.js $NODE_VERSION
-        docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.ARCH  }} staticnode
-    - name: Copy static node.js out
+        docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.NODE_ARCH  }} staticnode
+    - name: Test static node.js on manylinux2014
       run: |
-        mkdir $RUNNER_TEMP/static_node
-        docker run --rm -v $RUNNER_TEMP/static_node:/node_output ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:$NODE_VERSION cp -R -v -a /* /node_output/
-        ls -l -R $RUNNER_TEMP/static_node
-
-    - name: Test that it works
-      run: |
-        cd $RUNNER_TEMP/static_node
-        ./bin/node -v
-        ./bin/node -e "console.log('hello world')"
-        uname -a
+        docker build -f Dockerfile-test -t test-node --build-arg MANYLINUX_ARCH=${{ matrix.IMAGE.MANYLINUX_ARCH }} --build-arg CONTAINER_NAME=ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:$NODE_VERSION staticnode
+        docker run test-node /staticnode/bin/node -e "console.log('hello world'); console.log(process.version)"
     - name: Login to docker
       run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'
       env:
@@ -54,5 +46,5 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     - name: Push image
-      run: docker push ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.ARCH }}:${{ env.NODE_VERSION }}
+      run: docker push ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:${{ env.NODE_VERSION }}
       if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -37,7 +37,8 @@ jobs:
         docker build --tag ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=${{ matrix.IMAGE.NODE_ARCH  }} staticnode
     - name: Test static node.js on manylinux2014
       run: |
-        docker build -f Dockerfile-test -t test-node --build-arg MANYLINUX_ARCH=${{ matrix.IMAGE.MANYLINUX_ARCH }} --build-arg CONTAINER_NAME=ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:$NODE_VERSION staticnode
+        cd staticnode
+        docker build -f Dockerfile-test -t test-node --build-arg MANYLINUX_ARCH=${{ matrix.IMAGE.MANYLINUX_ARCH }} --build-arg CONTAINER_NAME=ghcr.io/pyca/static-nodejs-${{ matrix.IMAGE.NODE_ARCH }}:$NODE_VERSION .
         docker run test-node /staticnode/bin/node -e "console.log('hello world'); console.log(process.version)"
     - name: Login to docker
       run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'

--- a/cryptography-linux/Dockerfile
+++ b/cryptography-linux/Dockerfile
@@ -1,7 +1,8 @@
+ARG NODE_ARCH_RELEASE
 ARG PYCA_RELEASE
+FROM ghcr.io/pyca/static-nodejs-${NODE_ARCH_RELEASE} as staticnodejs
 FROM quay.io/pypa/${PYCA_RELEASE}
-ARG PYCA_RELEASE
-MAINTAINER Python Cryptographic Authority
+LABEL org.opencontainers.image.authors="Python Cryptographic Authority"
 WORKDIR /root
 RUN \
   if [ $(uname -m) = "x86_64" ]; \
@@ -16,22 +17,6 @@ RUN \
       apt-get install -qq -y --no-install-recommends prelink && \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
-    else \
-      # gcompat's latest release (as of 2024-02-04) doesn't support features we need for GH's node20 \
-      # so instead we build the entire thing ourselves from source. \
-      # Derived from https://git.alpinelinux.org/aports/tree/community/gcompat/APKBUILD?h=3.18-stable  \
-      # and pinned to the latest gcompat at the time this was written \
-      apk add --no-cache make libucontext-dev musl-obstack-dev; \
-      _ld="ld-linux-x86_64.so.2"; \
-      _arch="aarch64"; \
-      curl -O https://git.adelielinux.org/adelie/gcompat/-/archive/8e300a60/gcompat-ae300a60.tar.gz && \
-      tar xf gcompat*.tar.gz && \
-      cd gcompat* && \
-      make WITH_LIBUCONTEXT=1 WITH_OBSTACK=musl-obstack LINKER_PATH="/lib/ld-musl-${_arch}.so.1" LOADER_NAME="${_ld}" install && \
-      mkdir /lib64 &&\
-      ln -s "/lib/${_ld}" "/lib64/${_ld}" &&\
-      ln -s "/lib/${_ld}" /lib/libresolv.so.2 && \
-      cd .. && rm -rf gcompat*; \
     fi; \
   fi
 
@@ -50,25 +35,10 @@ RUN \
       apt-get install -qq -y --no-install-recommends libffi-dev && \
       apt-get clean -qq && \
       rm -rf /var/lib/apt/lists/*; \
-    else \
-      # gcompat's latest release (as of 2024-02-04) doesn't support features we need for GH's node20 \
-      # so instead we build the entire thing ourselves from source. \
-      # Derived from https://git.alpinelinux.org/aports/tree/community/gcompat/APKBUILD?h=3.18-stable  \
-      # and pinned to the latest gcompat at the time this was written \
-      apk add --no-cache make libucontext-dev musl-obstack-dev; \
-      _ld="ld-linux-aarch64.so.1"; \
-      _arch="aarch64"; \
-      curl -O https://git.adelielinux.org/adelie/gcompat/-/archive/8e300a60/gcompat-ae300a60.tar.gz && \
-      tar xf gcompat*.tar.gz && \
-      cd gcompat* && \
-      make WITH_LIBUCONTEXT=1 WITH_OBSTACK=musl-obstack LINKER_PATH="/lib/ld-musl-${_arch}.so.1" LOADER_NAME="${_ld}" install && \
-      mkdir /lib64 &&\
-      ln -s "/lib/${_ld}" "/lib64/${_ld}" &&\
-      ln -s "/lib/${_ld}" /lib/libresolv.so.2 && \
-      cd .. && rm -rf gcompat*; \
     fi; \
   fi
 
+COPY --from=staticnodejs /out/ /staticnode/
 ADD install_openssl.sh /root/install_openssl.sh
 ADD openssl-version.sh /root/openssl-version.sh
 RUN ./install_openssl.sh

--- a/runners/alpine/Dockerfile
+++ b/runners/alpine/Dockerfile
@@ -1,3 +1,6 @@
+ARG NODE_ARCH_RELEASE
+FROM ghcr.io/pyca/static-nodejs-${NODE_ARCH_RELEASE} as staticnodejs
+
 FROM alpine:latest
 
 # Increment this to blow away the docker cache
@@ -9,6 +12,8 @@ ENV LANG C.UTF-8
 
 RUN apk add --no-cache git libffi-dev curl \
     python3-dev openssl-dev bash gcc musl-dev tar pkgconfig zstd libucontext-dev musl-obstack-dev make
+
+COPY --from=staticnodejs /out/ /staticnode/
 
 # Derived from https://git.alpinelinux.org/aports/tree/community/gcompat/APKBUILD?h=3.18-stable and pinned to the
 # latest gcompat at the time this was written

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir -p /node_staging
 
 RUN curl -O https://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz
 RUN tar -zxvf node-$VERSION.tar.gz
-RUN cd node-$VERSION && ./configure --dest-cpu=$ARCH --fully-static && make -j4
-RUN cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node && rm -rf /build
-WORKDIR /out
-RUN tar -czvf /node_staging/node-$VERSION-static-$ARCH.tar.gz ./bin ./LICENSE
+RUN cd node-$VERSION && ./configure --dest-cpu=$ARCH --fully-static && make -j$(nproc)
+RUN cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node
+
+FROM scratch
+COPY --from=0 /out/ /out

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -10,6 +10,9 @@ RUN apk add --no-cache binutils-gold curl g++ gcc gnupg libgcc linux-headers mak
 RUN mkdir -p /out/bin
 RUN mkdir -p /node_staging
 
-RUN curl -O https://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz && tar -zxvf node-$VERSION.tar.gz && cd node-$VERSION && ./configure --dest-cpu=$ARCH --fully-static && make -j4 && cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node && rm -rf /build
+RUN curl -O https://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz
+RUN tar -zxvf node-$VERSION.tar.gz
+RUN cd node-$VERSION && ./configure --dest-cpu=$ARCH --fully-static && make -j4
+RUN cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node && rm -rf /build
 WORKDIR /out
 RUN tar -czvf /node_staging/node-$VERSION-static-$ARCH.tar.gz ./bin ./LICENSE

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+ARG VERSION
+# One of x64 or arm64
+ARG ARCH
+
+RUN mkdir -p /build
+WORKDIR /build
+
+RUN apk add --no-cache binutils-gold curl g++ gcc gnupg libgcc linux-headers make python3 libstdc++
+RUN mkdir -p /out/bin
+RUN mkdir -p /node_staging
+
+RUN curl -O https://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz && tar -zxvf node-$VERSION.tar.gz && cd node-$VERSION && ./configure --dest-cpu=$ARCH --fully-static && make -j4 && cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node && rm -rf /build
+WORKDIR /out
+RUN tar -czvf /node_staging/node-$VERSION-static-$ARCH.tar.gz ./bin ./LICENSE

--- a/staticnode/Dockerfile-test
+++ b/staticnode/Dockerfile-test
@@ -1,6 +1,6 @@
 ARG MANYLINUX_ARCH
 ARG CONTAINER_NAME
 FROM ${CONTAINER_NAME} as staticnodejs
-FROM quay.io/pypa/manylinux2014_${ARCH}
+FROM quay.io/pypa/manylinux2014_${MANYLINUX_ARCH}
 
 COPY --from=staticnodejs /out /staticnode/

--- a/staticnode/Dockerfile-test
+++ b/staticnode/Dockerfile-test
@@ -1,0 +1,6 @@
+ARG MANYLINUX_ARCH
+ARG CONTAINER_NAME
+FROM ${CONTAINER_NAME} as staticnodejs
+FROM quay.io/pypa/manylinux2014_${ARCH}
+
+COPY --from=staticnodejs /out /staticnode/

--- a/staticnode/node-version.sh
+++ b/staticnode/node-version.sh
@@ -1,0 +1,1 @@
+export NODE_VERSION="v20.13.1"


### PR DESCRIPTION
also copy it to /staticnode on manylinux2014 and alpine builders

The static-nodejs containers have already been pushed from a branch, but this PR should demonstrate the successful building of the manylinux and alpine containers.

Future improvements (follow up PR preferably due to the insanely painful cycle times on this):
* Figure out how to specify the node version tag in just one place rather than in every build arg.
* Use multi-stage builds to shrink the static-nodejs containers to just containing /out.
* Add the same hash checking we use for OpenSSL when building.