### PR TITLE
Remove buster image, it is EOL

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -38,7 +38,6 @@ jobs:
           - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", RUNNER: "ubuntu-latest"}
 
-          - {TAG_NAME: "cryptography-runner-buster", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=buster", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-bullseye", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bullseye", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-bookworm", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=bookworm", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-trixie", DOCKERFILE_PATH: "runners/debian", BUILD_ARGS: "--build-arg RELEASE=trixie", RUNNER: "ubuntu-latest"}


### PR DESCRIPTION
Don't merge until cryptography 43 is released