### PR TITLE
try using jom for parallel windows compilation

### DIFF
--- a/.github/workflows/build-windows-openssl.yml
+++ b/.github/workflows/build-windows-openssl.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
-      - run: choco install -y nasm winrar
+      - run: choco install -y nasm winrar jom
       - name: Export OpenSSL version
         run: |
           source ./cryptography-linux/openssl-version.sh

--- a/windows/openssl/build_openssl_win32.bat
+++ b/windows/openssl/build_openssl_win32.bat
@@ -1,9 +1,10 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
 SET PATH=%PATH%;C:\Program Files\NASM
+SET CL=/FS
 
 perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN32
-nmake
+jom -j4
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir ..\build

--- a/windows/openssl/build_openssl_win32.bat
+++ b/windows/openssl/build_openssl_win32.bat
@@ -4,7 +4,7 @@ SET PATH=%PATH%;C:\Program Files\NASM
 SET CL=/FS
 
 perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN32
-jom -j4
+jom
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir ..\build

--- a/windows/openssl/build_openssl_win64.bat
+++ b/windows/openssl/build_openssl_win64.bat
@@ -4,7 +4,7 @@ SET PATH=%PATH%;C:\Program Files\NASM
 SET CL=/FS
 
 perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN64A
-jom -j4
+jom
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir ..\build

--- a/windows/openssl/build_openssl_win64.bat
+++ b/windows/openssl/build_openssl_win64.bat
@@ -1,9 +1,10 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x64
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 SET PATH=%PATH%;C:\Program Files\NASM
+SET CL=/FS
 
 perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN64A
-nmake
+jom -j4
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir ..\build


### PR DESCRIPTION
This will speed us up significantly. However, it also increases the size of the static `.lib` files. This may just be an artifact of the order in which the linker does things, but we can verify everything behaves as expected in our test suite on the cryptography side once it merges as well.