### PR TITLE
Add ppc64le support to Docker images

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -72,7 +72,7 @@ jobs:
           - {TAG_NAME: "cryptography-manylinux_2_31:armv7l", DOCKERFILE_PATH: "cryptography-linux", DOCKER_PLATFORM: "linux/arm/v7", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_31_armv7l", RUNNER: "ubuntu-24.04-arm"}
           - {TAG_NAME: "cryptography-musllinux_1_2:armv7l", DOCKERFILE_PATH: "cryptography-linux", DOCKER_PLATFORM: "linux/arm/v7", BUILD_ARGS: "PYCA_RELEASE=musllinux_1_2_armv7l", RUNNER: "ubuntu-24.04-arm"}
 
-          - {TAG_NAME: "cryptography-runner-ubuntu-24.04:ppc64le", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=24.04", RUNNER: "ubuntu-24.04-ppc64le"}
+          - {TAG_NAME: "cryptography-runner-ubuntu-rolling:ppc64le", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=rolling", RUNNER: "ubuntu-24.04-ppc64le"}
           - {TAG_NAME: "cryptography-manylinux_2_28:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_28_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
           - {TAG_NAME: "cryptography-manylinux_2_34:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_34_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -74,7 +74,7 @@ jobs:
 
           - {TAG_NAME: "cryptography-runner-ubuntu-24.04:ppc64le", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=24.04", RUNNER: "ubuntu-24.04-ppc64le"}
           - {TAG_NAME: "cryptography-manylinux_2_28:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_28_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
-          - {TAG_NAME: "cryptography-manylinux2014:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux2014_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
+          - {TAG_NAME: "cryptography-manylinux_2_34:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux2014_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
 
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -72,6 +72,10 @@ jobs:
           - {TAG_NAME: "cryptography-manylinux_2_31:armv7l", DOCKERFILE_PATH: "cryptography-linux", DOCKER_PLATFORM: "linux/arm/v7", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_31_armv7l", RUNNER: "ubuntu-24.04-arm"}
           - {TAG_NAME: "cryptography-musllinux_1_2:armv7l", DOCKERFILE_PATH: "cryptography-linux", DOCKER_PLATFORM: "linux/arm/v7", BUILD_ARGS: "PYCA_RELEASE=musllinux_1_2_armv7l", RUNNER: "ubuntu-24.04-arm"}
 
+          - {TAG_NAME: "cryptography-runner-ubuntu-24.04:ppc64le", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=24.04", RUNNER: "ubuntu-24.04-ppc64le"}
+          - {TAG_NAME: "cryptography-manylinux_2_28:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_28_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
+          - {TAG_NAME: "cryptography-manylinux2014:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux2014_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
+
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -74,7 +74,7 @@ jobs:
 
           - {TAG_NAME: "cryptography-runner-ubuntu-24.04:ppc64le", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=24.04", RUNNER: "ubuntu-24.04-ppc64le"}
           - {TAG_NAME: "cryptography-manylinux_2_28:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_28_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
-          - {TAG_NAME: "cryptography-manylinux_2_34:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux2014_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
+          - {TAG_NAME: "cryptography-manylinux_2_34:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_34_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
 
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:

--- a/cryptography-linux/Dockerfile
+++ b/cryptography-linux/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/pypa/${PYCA_RELEASE}
 LABEL org.opencontainers.image.authors="Python Cryptographic Authority"
 WORKDIR /root
 RUN \
-  if [ $(uname -m) = "x86_64" ]; \
+  if [ $(uname -m) = "x86_64" ] || [ $(uname -m) = "ppc64le" ]; \
   then \
     if stat /etc/redhat-release 1>&2 2>/dev/null; then \
       yum -y install binutils perl perl-IPC-Cmd && \


### PR DESCRIPTION
This PR adds support for the ppc64le (PowerPC 64-bit Little Endian) architecture across multiple GitHub Actions workflows and Docker build configurations.

🔧 Changes made:

1. Wheel Builder Workflow (build-docker-images.yml)

Added two new manylinux containers for ppc64le:

manylinux2014:ppc64le
manylinux_2_28:ppc64le

2. Docker Image Builder Workflow (build-docker-images.yml)

Added definitions to build:
Runner base image: cryptography-runner-ubuntu-24.04:ppc64le
Wheel images: manylinux2014:ppc64le, manylinux_2_28:ppc64le

3. Dockerfile Update (cryptography-linux/Dockerfile)

Extended platform-specific install block to recognize ppc64le.