### PR TITLE
feat: add riscv64 Docker images for cryptography ecosystem

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -85,6 +85,12 @@ jobs:
           - {TAG_NAME: "cryptography-manylinux_2_28:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_28_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
           - {TAG_NAME: "cryptography-manylinux_2_34:ppc64le", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_34_ppc64le", RUNNER: "ubuntu-24.04-ppc64le"}
 
+          # riscv64 distro images
+          - {TAG_NAME: "cryptography-runner-ubuntu-rolling:riscv64", DOCKERFILE_PATH: "runners/ubuntu", BUILD_ARGS: "RELEASE=rolling", RUNNER: "ubuntu-24.04-riscv"}
+
+          # riscv64 manylinux images
+          - {TAG_NAME: "cryptography-manylinux_2_39:riscv64", DOCKERFILE_PATH: "cryptography-linux", BUILD_ARGS: "PYCA_RELEASE=manylinux_2_39_riscv64", RUNNER: "ubuntu-24.04-riscv"}
+
     name: "${{ matrix.IMAGE.TAG_NAME }}"
     steps:
       - uses: actions/checkout@v6.0.1

--- a/cryptography-linux/Dockerfile
+++ b/cryptography-linux/Dockerfile
@@ -7,7 +7,7 @@ FROM quay.io/pypa/${PYCA_RELEASE}
 LABEL org.opencontainers.image.authors="Python Cryptographic Authority"
 WORKDIR /root
 RUN \
-  if [ $(uname -m) = "x86_64" ] || [ $(uname -m) = "ppc64le" ]; \
+  if [ $(uname -m) = "x86_64" ] || [ $(uname -m) = "ppc64le" ] || [ $(uname -m) = "riscv64" ]; \
   then \
     if stat /etc/redhat-release 1>&2 2>/dev/null; then \
       yum -y install binutils perl perl-IPC-Cmd perl-Time-Piece && \


### PR DESCRIPTION
Add riscv64 entries to the Docker image build matrix using `manylinux_2_39` (first manylinux with riscv64 support) and RISE native runners (`ubuntu-24.04-riscv`).

## Changes

- **`.github/workflows/build-docker-images.yml`**: Add riscv64 runner and manylinux entries
- **`cryptography-linux/Dockerfile`**: Add riscv64 to binutils install block

## Images added

- `cryptography-runner-ubuntu-rolling:riscv64`
- `cryptography-manylinux_2_39:riscv64`

## Evidence

All pyca packages build from source on native riscv64 (BananaPi F3, SpacemiT K1). Native runners provided by [RISE](https://github.com/apps/rise-risc-v-runners).

Fixes #748