### PR TITLE
ci: add riscv64 to static Node.js build matrix

### DIFF
--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     runs-on: ${{ matrix.IMAGE.RUNNER }}
     needs: load-node-versions
+    timeout-minutes: 480
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-static-node.yml
+++ b/.github/workflows/build-static-node.yml
@@ -36,9 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE:
-          - {RUNNER: "ubuntu-latest", MANYLINUX_ARCH: "x86_64"}
-          - {RUNNER: "ubuntu-24.04-arm", MANYLINUX_ARCH: "aarch64"}
-          - {RUNNER: "ubuntu-24.04-ppc64le", MANYLINUX_ARCH: "ppc64le"}
+          - {RUNNER: "ubuntu-latest", MANYLINUX_IMAGE: "quay.io/pypa/manylinux2014_x86_64"}
+          - {RUNNER: "ubuntu-24.04-arm", MANYLINUX_IMAGE: "quay.io/pypa/manylinux2014_aarch64"}
+          - {RUNNER: "ubuntu-24.04-ppc64le", MANYLINUX_IMAGE: "quay.io/pypa/manylinux2014_ppc64le"}
+          - {RUNNER: "ubuntu-24.04-riscv", MANYLINUX_IMAGE: "quay.io/pypa/manylinux_2_39_riscv64"}
         NODE_CONFIG: ${{ fromJson(needs.load-node-versions.outputs.versions) }}
     steps:
     - uses: actions/checkout@v6.0.1
@@ -54,10 +55,10 @@ jobs:
       run: |
         echo building node.js $NODE_VERSION
         docker build --tag ghcr.io/pyca/static-nodejs-$NODE_ARCH:$NODE_VERSION --build-arg VERSION=$NODE_VERSION --build-arg ARCH=$NODE_ARCH --build-arg SHA256SUM=$NODE_SHA256SUM staticnode
-    - name: Test static node.js on manylinux2014
+    - name: Test static node.js
       run: |
         cd staticnode
-        docker build -f Dockerfile-test -t test-node --build-arg MANYLINUX_ARCH=${{ matrix.IMAGE.MANYLINUX_ARCH }} --build-arg CONTAINER_NAME=ghcr.io/pyca/static-nodejs-$NODE_ARCH:$NODE_VERSION .
+        docker build -f Dockerfile-test -t test-node --build-arg MANYLINUX_IMAGE=${{ matrix.IMAGE.MANYLINUX_IMAGE }} --build-arg CONTAINER_NAME=ghcr.io/pyca/static-nodejs-$NODE_ARCH:$NODE_VERSION .
         docker run test-node /staticnode/bin/node -e "console.log('hello world'); console.log(process.version)"
     - name: Login to docker
       run: 'docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" ghcr.io'

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.21
 ARG VERSION
 # One of x64 or arm64 or ppc64le or riscv64
 ARG ARCH

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -32,7 +32,9 @@ RUN cd node-$VERSION && \
       ppc64le) CPU=ppc64 ;; \
       *) CPU="$ARCH" ;; \
     esac && \
-    ./configure --dest-cpu=$CPU --fully-static --ninja --without-inspector --with-intl=none --without-npm --without-corepack && \
+    EXTRA_FLAGS="" && \
+    if [ "$ARCH" = "riscv64" ]; then EXTRA_FLAGS="--openssl-no-asm"; fi && \
+    ./configure --dest-cpu=$CPU --fully-static --ninja --without-inspector --with-intl=none --without-npm --without-corepack $EXTRA_FLAGS && \
     ninja -j$(nproc) -C out/Release node
 
 RUN cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node

--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 ARG VERSION
-# One of x64 or arm64 or ppc64le
+# One of x64 or arm64 or ppc64le or riscv64
 ARG ARCH
 # The sha256sum for the node source tarball
 ARG SHA256SUM
@@ -8,7 +8,11 @@ ARG SHA256SUM
 RUN mkdir -p /build
 WORKDIR /build
 
-RUN apk add --no-cache binutils-gold curl g++ gcc gnupg libgcc linux-headers make ninja python3 libstdc++ patch
+RUN if [ "$ARCH" = "riscv64" ]; then \
+      apk add --no-cache binutils curl g++ gcc gnupg libgcc linux-headers make ninja python3 libstdc++ patch; \
+    else \
+      apk add --no-cache binutils-gold curl g++ gcc gnupg libgcc linux-headers make ninja python3 libstdc++ patch; \
+    fi
 RUN mkdir -p /out/bin
 
 RUN curl -O https://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz

--- a/staticnode/Dockerfile-test
+++ b/staticnode/Dockerfile-test
@@ -1,6 +1,6 @@
-ARG MANYLINUX_ARCH
+ARG MANYLINUX_IMAGE
 ARG CONTAINER_NAME
 FROM ${CONTAINER_NAME} AS staticnodejs
-FROM quay.io/pypa/manylinux2014_${MANYLINUX_ARCH}
+FROM ${MANYLINUX_IMAGE}
 
 COPY --from=staticnodejs /out /staticnode/


### PR DESCRIPTION
Prerequisite for #749.

The `cryptography-linux/Dockerfile` pulls `ghcr.io/pyca/static-nodejs-riscv64:{version}` at build time, but that image does not exist yet because `build-static-node.yml` only covers x86_64, aarch64, and ppc64le.

Changes:
- Add `ubuntu-24.04-riscv` to the build matrix
- Update `Dockerfile-test` to accept a full `MANYLINUX_IMAGE` arg rather than constructing `quay.io/pypa/manylinux2014_{arch}` (manylinux2014 has no riscv64 image; riscv64 uses `manylinux_2_39_riscv64`)
- Update the test step accordingly

The main unknown is build time. Node.js does not ship riscv64 prebuilt binaries, so this builds from source inside Alpine on the RISE runner. Alex noted other platforms already take over an hour; the riscv64 result will show whether it is in a similar range.

Signed-off-by: Bruno Verachten <gounthar@gmail.com>