### PR TITLE
Revert "strip more out of the node build (#759)"

### DIFF
--- a/staticnode/Dockerfile
+++ b/staticnode/Dockerfile
@@ -28,7 +28,7 @@ RUN cd node-$VERSION && \
       ppc64le) CPU=ppc64 ;; \
       *) CPU="$ARCH" ;; \
     esac && \
-    ./configure --dest-cpu=$CPU --fully-static --ninja --without-inspector --with-intl=none --without-npm --without-corepack && \
+    ./configure --dest-cpu=$CPU --fully-static --ninja --without-inspector --with-intl=none && \
     ninja -j$(nproc) -C out/Release node
 
 RUN cp /build/node-$VERSION/LICENSE /out/LICENSE && cp /build/node-$VERSION/out/Release/node /out/bin/node


### PR DESCRIPTION
This reverts commit 7ead6ba10e256e3853c7437e53d525724504b1f4.

pre-emptive PR just in case we need it since these builds take so long