### PR TITLE
Remove FIPS variants from Docker build matrix

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -33,12 +33,8 @@ jobs:
       matrix:
         IMAGE:
           # x86-64 distro images
-          - {TAG_NAME: "cryptography-runner-rhel8", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "RELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-rhel8-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "FIPS=1\nRELEASE=redhat/ubi8", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-centos-stream9", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "RELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-centos-stream9-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "FIPS=1\nRELEASE=quay.io/centos/centos:stream9", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-centos-stream10", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "RELEASE=quay.io/centos/centos:stream10", RUNNER: "ubuntu-latest"}
-          - {TAG_NAME: "cryptography-runner-centos-stream10-fips", DOCKERFILE_PATH: "runners/rhel", BUILD_ARGS: "FIPS=1\nRELEASE=quay.io/centos/centos:stream10", RUNNER: "ubuntu-latest"}
 
           - {TAG_NAME: "cryptography-runner-fedora", DOCKERFILE_PATH: "runners/fedora", RUNNER: "ubuntu-latest"}
           - {TAG_NAME: "cryptography-runner-alpine", DOCKERFILE_PATH: "runners/alpine", RUNNER: "ubuntu-latest"}


### PR DESCRIPTION
RHEL8 is no longer used in our CI, nor are the stream FIPS versions. Depends on https://github.com/pyca/cryptography/pull/14809