### PR TITLE
Fail the build if the rustup install download fails

### DIFF
--- a/cryptography-linux/Dockerfile
+++ b/cryptography-linux/Dockerfile
@@ -32,5 +32,7 @@ ADD openssl-version.sh /root/openssl-version.sh
 ADD generate_sbom.py /root/generate_sbom.py
 RUN ./install_openssl.sh
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+RUN curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal && \
+    rm /tmp/rustup-init.sh
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/debian/Dockerfile
+++ b/runners/debian/Dockerfile
@@ -23,5 +23,7 @@ RUN apt-get -qq update && apt-get install -qq -y \
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
+RUN curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --component llvm-tools-preview && \
+    rm /tmp/rustup-init.sh
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/rhel/Dockerfile
+++ b/runners/rhel/Dockerfile
@@ -10,5 +10,7 @@ RUN if [ "$FIPS" = "1" ] ; then if [ "$RELEASE" = "redhat/ubi8" ] ; then rm -rf 
 
 RUN if [ "$RELEASE" = "redhat/ubi8" ] ; then python3.8 -m venv /venv; else python3 -m venv /venv; fi; /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
+RUN curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --component llvm-tools-preview && \
+    rm /tmp/rustup-init.sh
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/runners/ubuntu/Dockerfile
+++ b/runners/ubuntu/Dockerfile
@@ -37,5 +37,7 @@ RUN if [ "$(readelf -h /proc/self/exe | grep -o 'Machine:.* ARM')" ]; \
 
 RUN python3 -m venv /venv && /venv/bin/pip install -U pip wheel --no-cache-dir
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --component llvm-tools-preview
+RUN curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --component llvm-tools-preview && \
+    rm /tmp/rustup-init.sh
 ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
## Problem

All the `curl https://sh.rustup.rs -sSf | sh -s -- ...` rustup installs share a footgun: a shell pipeline's exit status is that of the **last** command, not `curl`. So when `curl` fails — e.g. the transient `curl: (6) Could not resolve host: sh.rustup.rs` seen in the [2026-05-22 scheduled Docker Image Builder run](https://github.com/pyca/infra/actions/runs/26261783918/job/77296594478) — it writes nothing to stdout, the downstream `sh` reads empty stdin and exits `0`, and the Docker layer "succeeds." The result is an image **with no Rust toolchain**, pushed to the mutable `:ppc64le` tag.

### Downstream blast radius

That Rust-less `cryptography-manylinux_2_28:ppc64le` image then broke pyca/cryptography wheel/test jobs. With no `cargo` on `PATH`, maturin's PEP 517 `get_requires_for_build_wheel` hook does:

```python
if not os.environ.get("MATURIN_NO_INSTALL_RUST") and not shutil.which("cargo"):
    requirements += ["puccinialin"]
```

`puccinialin` isn't pinned in cryptography's hashed `build-requirements.txt`, so `uv build --require-hashes` aborts with `In --require-hashes mode, all requirements must be pinned upfront with ==, but found: puccinialin`. Everything in cryptography was correctly pinned — the unpinned, half-built container image was the culprit.

## Fix

Download the script first, then run it as a separate `&&`-chained step, so a failed download fails the layer loudly:

```dockerfile
RUN curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh && \
    sh /tmp/rustup-init.sh -y <args> && \
    rm /tmp/rustup-init.sh
```

Applied to all four affected Dockerfiles (`cryptography-linux`, `runners/{ubuntu,debian,rhel}`). Kept as POSIX `sh` (no `pipefail`/bash dependency) so it works on every base image and doesn't alter the shell for other `RUN`s. `runners/fedora` and `runners/alpine` are unaffected — they install rust via the distro `rustup` package and call `rustup-init` directly, no pipe.

After merge, re-running the image builder will rebuild a correct image and unstick cryptography CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)