### PR TITLE
Fix Windows OpenSSL build: locate VS via vswhere instead of hardcoded VS2022 path

### DIFF
--- a/.github/workflows/build-windows-openssl.yml
+++ b/.github/workflows/build-windows-openssl.yml
@@ -29,7 +29,7 @@ jobs:
           - {ARCH: "win32", RUNNER: "windows-latest"}
           - {ARCH: "win64", RUNNER: "windows-latest"}
           - {ARCH: "arm64", RUNNER: "windows-11-arm"}
-    name: "Build OpenSSL for ${{ matrix.ARCH.ARCH }} on MSVC 2022"
+    name: "Build OpenSSL for ${{ matrix.ARCH.ARCH }} on MSVC"
     steps:
       - uses: actions/checkout@v6.0.3
         with:

--- a/windows/openssl/build_openssl.bat
+++ b/windows/openssl/build_openssl.bat
@@ -5,19 +5,31 @@ cd openssl-*
 
 SET PATH=%PATH%;C:\Program Files\NASM
 SET CL=/FS
+
+REM Locate the Visual Studio install rather than hardcoding a version/edition,
+REM so this keeps working as GitHub bumps the runner image (e.g. VS2022 -> VS2026).
+REM The GitHub runner images put vswhere on PATH. If that ever stops being true,
+REM it's installed by the VS Installer at a fixed location:
+REM   "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -property installationPath`) do set VSINSTALL=%%i
+if not defined VSINSTALL (
+    echo Could not locate a Visual Studio installation via vswhere
+    exit /b 1
+)
+
 if "%BUILDARCH%" == "win32" (
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+    CALL "%VSINSTALL%\Common7\Tools\VsDevCmd.bat" -arch=x86
+    CALL "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" x86
 
     perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN32
 ) else if "%BUILDARCH%" == "win64" (
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x64
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+    CALL "%VSINSTALL%\Common7\Tools\VsDevCmd.bat" -arch=x64
+    CALL "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
     perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN64A
 ) else if "%BUILDARCH%" == "arm64" (
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=arm64
-    CALL "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+    CALL "%VSINSTALL%\Common7\Tools\VsDevCmd.bat" -arch=arm64
+    CALL "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" arm64
 
     perl Configure %OPENSSL_BUILD_FLAGS_WINDOWS% VC-WIN64-ARM
 )


### PR DESCRIPTION
## Problem

The scheduled `Windows OpenSSL` build started failing ([run 27798510868](https://github.com/pyca/infra/actions/runs/27798510868/job/82263479543)). GitHub flipped the `windows-latest` runner image from `windows-2025` (Visual Studio 2022) to `windows-2025-vs2026` (Visual Studio 2026).

`windows/openssl/build_openssl.bat` hardcoded the VS **2022** install path:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\...
```

On the new image that path doesn't exist, so the job log shows `The system cannot find the path specified` — `vcvarsall.bat` never ran, the MSVC toolchain wasn't on PATH, and the win32/win64 builds failed with exit code 2. (The arm64 job runs on `windows-11-arm`, a separate image still on VS2022, so it kept passing.)

## Fix

Discover the VS install path with `vswhere` instead of hardcoding a version/edition. `vswhere` is on PATH on the GitHub runner images (a comment records the fixed VS Installer fallback path in case that ever changes), and it returns whatever VS is installed — so this works on VS2026 now and future-proofs the arm64 job for when that image eventually moves to VS2026 too.

Also drops the now-inaccurate "MSVC 2022" from the job name.

## Testing

Verified against the actual runner images:
- `vswhere` ships on both the `windows-2025-vs2026` and `windows-11-arm64` images and resolves to the correct VS install path on each.

Recommend kicking off a `workflow_dispatch` run to confirm all three arches (win32/win64/arm64) build cleanly before relying on the next scheduled Friday build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)