### PR TITLE
Use tar instead of WinRAR to extract OpenSSL source on Windows

### DIFF
--- a/.github/workflows/build-windows-openssl.yml
+++ b/.github/workflows/build-windows-openssl.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - run: choco install -y nasm winrar jom
+      - run: choco install -y nasm jom
       - name: Export OpenSSL version
         run: |
           source ./cryptography-linux/openssl-version.sh
@@ -49,7 +49,7 @@ jobs:
               Write-Error 'Hashes do not match' -ErrorAction Stop
           }
         shell: powershell
-      - run: '"C:\Program Files\WinRAR\WinRAR.exe" -INUL x openssl-latest.tar.gz'
+      - run: tar -xzf openssl-latest.tar.gz
         shell: cmd
       - run: windows\openssl\build_openssl.bat ${{ matrix.ARCH.ARCH }}
         shell: cmd


### PR DESCRIPTION
The 2026-07-03 scheduled [Windows OpenSSL run](https://github.com/pyca/infra/actions/runs/28630438416) failed on all three arches because the Chocolatey community feed returned 503s, `choco install` exited 0 despite installing nothing, and the jobs then died at the extraction step because WinRAR was missing.

WinRAR is only used to extract the OpenSSL tarball, and bsdtar ships on all Windows runners (including `windows-11-arm`), so use `tar` and drop the WinRAR dependency entirely. `nasm` and `jom` are still needed by `build_openssl.bat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)